### PR TITLE
[DCOS-40448] Bump (and pin) packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 # https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian95---linux-amd64
 FROM debian@sha256:f1f61086ea01a72b30c7287adee8c929e569853de03b7c462a8ac75e0d0224c4
 
-ARG JUPYTER_DCOS_VERSION="1.2.0-0.33.7"
 ARG BUILD_DATE
 ARG CODENAME="stretch"
 ARG CONDA_DIR="/opt/conda"
@@ -14,6 +13,7 @@ ARG DCOS_CLI_URL="https://downloads.dcos.io/binaries/cli/linux/x86-64"
 ARG DCOS_CLI_VERSION="1.11"
 ARG DCOS_COMMONS_URL="https://downloads.mesosphere.com/dcos-commons"
 ARG DCOS_COMMONS_VERSION="0.51.0"
+ARG DCOS_JUPYTERLAB_VERSION="1.2.0-0.33.8"
 ARG DEBCONF_NONINTERACTIVE_SEEN="true"
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG DEBIAN_REPO="http://cdn-fastly.deb.debian.org"
@@ -73,8 +73,8 @@ LABEL maintainer="Vishnu Mohan <vishnu@mesosphere.com>" \
       org.label-schema.description="Project Jupyter exists to develop open-source software, open-standards, and services for interactive computing across dozens of programming languages." \
       org.label-schema.url="http://jupyter.org" \
       org.label-schema.vcs-ref="${VCS_REF}" \
-      org.label-schema.vcs-url="https://github.com/dcos-labs/dcos-jupyter-service" \
-      org.label-schema.version="${JUPYTER_DCOS_VERSION}" \
+      org.label-schema.vcs-url="https://github.com/dcos-labs/dcos-jupyterlab-service" \
+      org.label-schema.version="${DCOS_JUPYTERLAB_VERSION}" \
       org.label-schema.schema-version="1.0"
 
 ENV BOOTSTRAP="${MESOSPHERE_PREFIX}/bin/bootstrap" \
@@ -240,15 +240,19 @@ RUN cd /tmp \
     && bash "./${CONDA_INSTALLER}" -u -b -p "${CONDA_DIR}" \
     && ${CONDA_DIR}/bin/conda update --json --all -yq \
     && ${CONDA_DIR}/bin/pip install --upgrade pip \
+    && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::blas \
+    && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::gsl \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::numpy-base \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::numpy \
+    && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::openblas \
+    && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::scikit-learn \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::scipy \
     && ${CONDA_DIR}/bin/conda config --system --prepend channels conda-forge \
     && ${CONDA_DIR}/bin/conda config --system --set auto_update_conda false \
     && ${CONDA_DIR}/bin/conda config --system --set show_channel_urls true \
     && ${CONDA_DIR}/bin/conda env update --json -q -f "${CONDA_DIR}/${CONDA_ENV_YML}" \
     && ${CONDA_DIR}/bin/jupyter toree install --sys-prefix --interpreters=Scala,PySpark,SparkR,SQL \
-    && ${CONDA_DIR}/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36.1 \
+    && ${CONDA_DIR}/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36.2 \
     && ${CONDA_DIR}/bin/jupyter labextension install @jupyterlab/fasta-extension \
     && ${CONDA_DIR}/bin/jupyter labextension install @jupyterlab/geojson-extension \
     && ${CONDA_DIR}/bin/jupyter labextension install @jupyterlab/github \
@@ -262,7 +266,6 @@ RUN cd /tmp \
     && ${CONDA_DIR}/bin/jupyter labextension install jupyterlab_bokeh \
     && ${CONDA_DIR}/bin/jupyter labextension install jupyterlab-kernelspy \
     && ${CONDA_DIR}/bin/jupyter labextension install knowledgelab \
-    && ${CONDA_DIR}/bin/jupyter labextension install qgrid \
     && ${CONDA_DIR}/bin/jupyter-nbextension install --py --sys-prefix rise \
     && ${CONDA_DIR}/bin/jupyter nbextension install --py --sys-prefix sparkmonitor \
     && ${CONDA_DIR}/bin/jupyter nbextension enable --py --sys-prefix sparkmonitor \

--- a/jupyter-root-conda-base-env.yml
+++ b/jupyter-root-conda-base-env.yml
@@ -34,7 +34,7 @@ dependencies:
 - ipywidgets=7.4.0
 - itsdangerous
 - jupyter_contrib_nbextensions
-- jupyterlab=0.33.7
+- jupyterlab=0.33.8
 - keras
 - libhdfs3
 - lxml
@@ -52,7 +52,6 @@ dependencies:
 - pep8
 - pillow
 - pluggy
-- protobuf
 - psutil
 - py
 - pyarrow
@@ -63,10 +62,10 @@ dependencies:
 - r-base
 - r-irkernel
 - s3fs
+- setuptools=40.0.0
 - scikit-learn
 - scipy
 - selenium
-- setuptools
 - smmap2
 - tabulate
 - widgetsnbextension=3.4.0
@@ -83,11 +82,12 @@ dependencies:
   - https://github.com/vishnu2kmohan/jupyter-spark-history-dcos/archive/0.1.0.zip
   - jupyterlab_github
   - knowledgelab
-  - mlflow==0.4.1
+  - mlflow==0.4.2
   - opencv-python
   - pixiedust
   - pixiedust_node
   - pixiegateway
+  - protobuf==3.6.0
   - pyglet
   - PyOpenGL
   - ray[rllib]==0.5.0


### PR DESCRIPTION
- Bump JupyterLab to 0.33.8, @jupyter-widgets/jupyterlab-manager@0.36.2
- Bump MLFlow to 0.4.2
- Pin `blas`, `gsl`, `openblas`, `scikit-learn` to the `default` conda channel
- Remove `qgrid` until package builds at a later date (currently complains about missing `package.json`)
- Pin `setuptools` to 40.0.0 and `protobuf` to 3.6.0 (required for MLFlow 0.4.2)

Note: We'll bump to TensorFlow 1.10.0 at a later date, when the ecosystem packages (Hadoop and Spark conectors) are updated.
