### PR TITLE
fixed hdfs race condition with TensorBoard

### DIFF
--- a/start-tensorboard.sh
+++ b/start-tensorboard.sh
@@ -2,6 +2,12 @@
 
 set -o errexit -o pipefail
 
+# Block until jupyter configuration is complete, as otherwise dependencies such as HDFS might not be downloaded yet.
+while [ ! -f "${MESOS_SANDBOX}"/JUPYTER_NOTEBOOK_CONFIG_COMPLETE ]
+do
+  sleep 2
+done
+
 TENSORBOARD_LOGDIR=${TENSORBOARD_LOGDIR:-"${MESOS_SANDBOX}"}
 
 if [ ${PORT_TFDBG+x} ]; then

--- a/start.sh
+++ b/start.sh
@@ -74,17 +74,8 @@ else
     fi
 
     # Start Tensorboard?
-    # TODO(joerg84): USE SCRIPT HERE
     if [ ${START_TENSORBOARD+x} ]; then
-        TENSORBOARD_LOGDIR=${TENSORBOARD_LOGDIR:-"${MESOS_SANDBOX}"}
-        if [ ${PORT_TFDBG+x} ]; then
-            TENSORBOARD_ARGS="${TENSORBOARD_ARGS} --debugger_port ${PORT_TFDBG}"
-        fi
-        tensorboard \
-            --host localhost \
-            --port 6006 \
-            --logdir "${TENSORBOARD_LOGDIR}" \
-            "${TENSORBOARD_ARGS}" 2>&1 &
+        /usr/local/bin/start-tensorboard.sh 2>&1 &
     fi
 
     # Start Dask Distributed Scheduler?


### PR DESCRIPTION
When providing Jupyter Configuration URLs with HDFS support as a result of a race condition, TensorBoard throws:

```
hdfsExists: invokeMethod((Lorg/apache/hadoop/fs/Path;)Z) error:
java.lang.IllegalArgumentException: Pathname /../checkpoint from /../checkpoint is not a valid DFS filename.
    at org.apache.hadoop.hdfs.DistributedFileSystem.getPathName(DistributedFileSystem.java:221)
    at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1529)
    at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1526)
    at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
    at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1526)
    at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1627)
```

The modifications I made prevent TensorBoard from starting before HDFS was correctly configured.

Changes diff in:
https://github.com/dcos-labs/dcos-jupyterlab-service/blob/fabianbaier-race-hdfs/start-tensorboard.sh#L5-L9
https://github.com/dcos-labs/dcos-jupyterlab-service/blob/fabianbaier-race-hdfs/start.sh#L76-L79