### PR TITLE
[DCOS-40629] Bump and add useful packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ARG CONDA_URL="https://repo.continuum.io/miniconda"
 ARG DCOS_CLI_URL="https://downloads.dcos.io/binaries/cli/linux/x86-64"
 ARG DCOS_CLI_VERSION="1.11"
 ARG DCOS_COMMONS_URL="https://downloads.mesosphere.com/dcos-commons"
-ARG DCOS_COMMONS_VERSION="0.51.0"
-ARG DCOS_JUPYTERLAB_VERSION="1.2.0-0.33.8"
+ARG DCOS_COMMONS_VERSION="0.53.0"
+ARG DCOS_JUPYTERLAB_VERSION="1.2.0-0.34.0"
 ARG DEBCONF_NONINTERACTIVE_SEEN="true"
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG DEBIAN_REPO="http://cdn-fastly.deb.debian.org"
@@ -241,6 +241,7 @@ RUN cd /tmp \
     && ${CONDA_DIR}/bin/conda update --json --all -yq \
     && ${CONDA_DIR}/bin/pip install --upgrade pip \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::blas \
+    && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::conda \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::gsl \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::numpy-base \
     && ${CONDA_DIR}/bin/conda config --env --add pinned_packages defaults::numpy \
@@ -252,7 +253,7 @@ RUN cd /tmp \
     && ${CONDA_DIR}/bin/conda config --system --set show_channel_urls true \
     && ${CONDA_DIR}/bin/conda env update --json -q -f "${CONDA_DIR}/${CONDA_ENV_YML}" \
     && ${CONDA_DIR}/bin/jupyter toree install --sys-prefix --interpreters=Scala,PySpark,SparkR,SQL \
-    && ${CONDA_DIR}/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36.2 \
+    && ${CONDA_DIR}/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.37.2 \
     && ${CONDA_DIR}/bin/jupyter labextension install @jupyterlab/fasta-extension \
     && ${CONDA_DIR}/bin/jupyter labextension install @jupyterlab/geojson-extension \
     && ${CONDA_DIR}/bin/jupyter labextension install @jupyterlab/github \
@@ -264,7 +265,6 @@ RUN cd /tmp \
     && ${CONDA_DIR}/bin/jupyter labextension install beakerx-jupyterlab@1.0.0 \
     && ${CONDA_DIR}/bin/jupyter labextension install bqplot \
     && ${CONDA_DIR}/bin/jupyter labextension install jupyterlab_bokeh \
-    && ${CONDA_DIR}/bin/jupyter labextension install jupyterlab-kernelspy \
     && ${CONDA_DIR}/bin/jupyter labextension install knowledgelab \
     && ${CONDA_DIR}/bin/jupyter-nbextension install --py --sys-prefix rise \
     && ${CONDA_DIR}/bin/jupyter nbextension install --py --sys-prefix sparkmonitor \
@@ -275,7 +275,7 @@ RUN cd /tmp \
     && ipython profile create \
     && echo "c.InteractiveShellApp.extensions.append('sparkmonitor.kernelextension')" \
        >> $(ipython profile locate default)/ipython_kernel_config.py \
-    && ${CONDA_DIR}/bin/conda remove --force --json -yq openjdk pyqt qt \
+    && ${CONDA_DIR}/bin/conda remove --force --json -yq openjdk pyqt qt qtconsole \
     && ${CONDA_DIR}/bin/npm cache clean --force \
     && rm -rf "${CONDA_DIR}/share/jupyter/lab/staging"  "${HOME}/.npm/_cacache" \
     && rm -rf "${HOME}/.cache/pip" "${HOME}/.cache/yarn" "${HOME}/.node-gyp" \

--- a/Dockerfile-cuDNN
+++ b/Dockerfile-cuDNN
@@ -67,7 +67,6 @@ COPY --chown="1000:100" "${CONDA_ENV_YML}" "${CONDA_DIR}/"
 USER $NB_UID
 
 RUN ${CONDA_DIR}/bin/conda env update --json -q -f "${CONDA_DIR}/${CONDA_ENV_YML}" \
-    && ${CONDA_DIR}/bin/conda update --json --all -yq \
     && ${CONDA_DIR}/bin/conda remove --force --json -yq cudatoolkit \
     && ${CONDA_DIR}/bin/conda clean --json -tipsy \
     && ${CONDA_DIR}/bin/npm cache clean --force \

--- a/jupyter-root-conda-base-env.yml
+++ b/jupyter-root-conda-base-env.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- alembic
 - altair
 - astunparse
 - atomicwrites
@@ -12,6 +13,7 @@ dependencies:
 - beakerx=1.0.0
 - beautifulsoup4
 - bokeh
+- cachetools
 - click
 - colour
 - cython
@@ -24,17 +26,24 @@ dependencies:
 - flask
 - funcsigs
 - future
+- gcsfs
 - geojson
 - gitdb2
 - gitpython
-- gunicorn
+- google-auth
+- google-auth-oauthlib
 - grpcio
+- gunicorn
 - h5py
 - invoke
 - ipywidgets=7.4.0
 - itsdangerous
+- jupyter
+- jupyterlab=0.34.0
+- jupyter_console
 - jupyter_contrib_nbextensions
-- jupyterlab=0.33.8
+- jupyter_enterprise_gateway
+- jupyter_kernel_gateway
 - keras
 - libhdfs3
 - lxml
@@ -46,28 +55,38 @@ dependencies:
 - mpld3
 - nbconvert
 - nodejs=9.*
+- nose
 - numpy=1.15.0
 - numpy-base=1.15.0
+- oauthlib
 - pandas
 - pep8
 - pillow
 - pluggy
 - psutil
+- psycopg2
 - py
 - pyarrow
+- pydotplus
 - pyfolio
 - pytest
 - python=3.6.*
+- python-editor
 - python-snappy
+- qtconsole
 - r-base
 - r-irkernel
+- requests-oauthlib
 - s3fs
-- setuptools=40.0.0
 - scikit-learn
 - scipy
 - selenium
+- simplejson
 - smmap2
+- sqlalchemy
 - tabulate
+- tox
+- virtualenv
 - widgetsnbextension=3.4.0
 - wrapt
 - xgboost
@@ -75,15 +94,18 @@ dependencies:
 - yapf
 - pip:
   - configparser
+  - databricks-cli
   - flatbuffers
   - gym[atari]
   - horovod
-  - https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc6/toree-pip/toree-0.2.0.tar.gz
+  - https://dist.apache.org/repos/dist/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
   - https://github.com/vishnu2kmohan/jupyter-spark-history-dcos/archive/0.1.0.zip
   - jupyterlab_github
   - knowledgelab
-  - mlflow==0.4.2
+  - mlflow==0.5.0
+  - nb2kg
   - opencv-python
+  - pgcontents
   - pixiedust
   - pixiedust_node
   - pixiegateway
@@ -93,6 +115,8 @@ dependencies:
   - ray[rllib]==0.5.0
   - redis
   - rise
+  - s3contents
+  - setuptools==40.0.0
   - sparkmonitor
   - tensorflow==1.9.0
   - tensorflow-hub

--- a/jupyter-root-conda-cudnn-env.yml
+++ b/jupyter-root-conda-cudnn-env.yml
@@ -1,12 +1,12 @@
 name: root
 channels:
 - conda-forge
-- pytorch
 - defaults
 dependencies:
 - cuda90
 - numba
-- pytorch
-- torchvision
+- pytorch::pytorch
+- pytorch::torchvision
 - pip:
+  - setuptools==40.0.0
   - tensorflow-gpu==1.9.0


### PR DESCRIPTION
Added:
- nb2kg
- jupyter_enterprise_gateway
- jupyter_kernel_gateway
- pgcontents
- pydotplus
- s3contents

Updated:
- JupyterLab to 0.34.0
- MLFlow to 0.5.0
- Apache Toree to 0.2.0-incubating, which is the latest release version, no more `-rc` :tada: 

Note: The TensorFlow 1.10.0 pip (wheel) package has a broken dependency on an older version `numpy`: 
```
tensorflow 1.10.0 has requirement numpy<=1.14.5,>=1.13.3, but you'll have numpy 1.15.0 which is incompatible.
```

TensorFlow 1.9.0 however, works just fine with `numpy` 1.15.0 AFAICT :man_shrugging: 