### PR TITLE
Fixup TFoS.ipynb

### DIFF
--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -24,26 +24,39 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "# CPU Config\n",
     "conf = SparkConf().setAppName('Mnist') \\\n",
-    "                          .set('spark.mesos.executor.docker.image', 'dcoslabs/dcos-jupyterlab:1.2.0-0.33.7') \n"
+    "                          .set('spark.mesos.executor.docker.image', 'dcoslabs/dcos-spark:1.11.4-2.2.1') \n"
    ]
   },
   {
    "cell_type": "code",
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "# GPU Config\n",
     "#conf = SparkConf().setAppName('Mnist-GPU') \\\n",
+    "#                          .set('spark.mesos.executor.docker.image', 'dcoslabs/dcos-spark:1.11.4-2.2.1-gpu') \n",
     "#                          .set('spark.mesos.gpus.max', 5) \\\n",
     "#                          .set('spark.mesos.executor.gpus', 1)"
    ]
   },
- {
+  {
    "cell_type": "code",
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "sc = SparkContext(conf=conf).getOrCreate()\n",
     "sc.addPyFile('TensorFlowOnSpark/examples/mnist/spark/mnist_dist.py')"
@@ -306,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add Notebook JSON fields so that it loads in the Classic Jupyter Notebook (5.6.0) and (explicitly) use the smaller Spark Executor Docker Images.