### PR TITLE
TF 1.11 Dataset API Notebook Patch

### DIFF
--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -43,8 +43,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Clone the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark\n",
-    "subprocess.check_output('cd $MESOS_SANDBOX && git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark', shell=True)"
+    "# Clone repo with adjusted TF 1.11 APIs in mnist_dist/mnist_spark\n",
+    "subprocess.check_output('cd $MESOS_SANDBOX && git clone https://github.com/yahoo/tensorflowonspark', shell=True)"
    ]
   },
   {
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create mnist data in csv2 format\n",
+    "# Create mnist data in tfr format\n",
     "subprocess.check_output('eval spark-submit ${SPARK_OPTS} --verbose tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/tfr --format tfr', shell=True)"
    ]
   },
@@ -106,7 +106,7 @@
    "source": [
     "# # CPU Config\n",
     "# conf = SparkConf().setAppName('Mnist-CPU') \\\n",
-    "#                   .set('spark.mesos.executor.docker.image', 'fabianbaier/data-toolkit:latest-gpu') \n"
+    "#                   .set('spark.mesos.executor.docker.image', 'mesosphere/mesosphere-data-toolkit:latest') \n"
    ]
   },
   {
@@ -132,7 +132,7 @@
    },
    "outputs": [],
    "source": [
-    "# Make sure you cloned the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark : git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark\n",
+    "# Make sure you cloned the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark\n",
     "sc = SparkContext(conf=conf).getOrCreate()\n",
     "sc.addPyFile('tensorflowonspark/examples/mnist/tf/mnist_dist.py')"
    ]
@@ -169,7 +169,7 @@
    "outputs": [],
    "source": [
     "# Verify training images\n",
-    "# Make sure you unzipped mnist.zip into mnist and ran the mnist_data_setup job via: eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2\n",
+    "# Make sure you unzipped mnist.zip into mnist and ran the mnist_data_setup job via: eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/tfr --format tfr\n",
     "train_images_files = \"mnist/tfr/train\"\n",
     "print(subprocess.check_output(shlex.split('hdfs dfs -ls -R {}'.format(train_images_files))))"
    ]

--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -13,7 +13,6 @@
     "from __future__ import print_function\n",
     "\n",
     "import logging\n",
-    "from datetime import datetime\n",
     "import argparse\n",
     "import subprocess\n",
     "import shlex\n",
@@ -33,8 +32,8 @@
     "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash mnist', shell=True)\n",
     "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash mnist_model', shell=True)\n",
     "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash predictions', shell=True)\n",
-    "subprocess.check_output('rm -Rf mnist tensorflowonspark', shell=True)\n",
-    "subprocess.check_output('rm -f mnist.zip', shell=True)"
+    "subprocess.check_output('cd $MESOS_SANDBOX && rm -Rf mnist tensorflowonspark', shell=True)\n",
+    "subprocess.check_output('cd $MESOS_SANDBOX && rm -f mnist.zip', shell=True)"
    ]
   },
   {
@@ -236,11 +235,8 @@
    "outputs": [],
    "source": [
     "# Parse arguments for inference\n",
-    "args = parser.parse_args(['--mode', 'inference', '--epochs', '3',\n",
-    "                          '--batch_size', '100',\n",
+    "args = parser.parse_args(['--mode', 'inference',\n",
     "                          '--images_labels', train_images_files,\n",
-    "                          '--format', 'tfr',\n",
-    "                          '--steps', '10000',\n",
     "                          '--output', 'predictions',\n",
     "                          '--model', 'mnist_model'])\n",
     "print(args)"
@@ -301,6 +297,13 @@
    "source": [
     "sc.stop()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -13,6 +13,7 @@
     "from __future__ import print_function\n",
     "\n",
     "import logging\n",
+    "from datetime import datetime\n",
     "import argparse\n",
     "import subprocess\n",
     "import shlex\n",
@@ -24,47 +25,196 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b''"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Remove existing models/artifacts if any\n",
+    "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash mnist', shell=True)\n",
+    "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash mnist_model', shell=True)\n",
+    "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash predictions', shell=True)\n",
+    "subprocess.check_output('rm -Rf mnist tensorflowonspark', shell=True)\n",
+    "subprocess.check_output('rm -f mnist.zip', shell=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b''"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Clone the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark\n",
+    "subprocess.check_output('git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark', shell=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'Archive:  mnist.zip\\n   creating: mnist/\\n  inflating: mnist/train-images-idx3-ubyte.gz  \\n extracting: mnist/train-labels-idx1-ubyte.gz  \\n  inflating: mnist/t10k-images-idx3-ubyte.gz  \\n extracting: mnist/t10k-labels-idx1-ubyte.gz  \\n'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Download the mnist example \n",
+    "subprocess.check_output('curl -fsSL -O https://downloads.mesosphere.com/data-science/assets/mnist.zip && unzip mnist.zip', shell=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b\"args: Namespace(format='csv2', num_partitions=10, output='mnist/csv2', read=False, verify=False)\\n2018-11-04 05:05:31,984 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Running Spark version 2.2.1\\n2018-11-04 05:05:32,012 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Submitted application: mnist_parallelize\\n2018-11-04 05:05:32,030 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing view acls to: nobody\\n2018-11-04 05:05:32,031 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing modify acls to: nobody\\n2018-11-04 05:05:32,031 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing view acls groups to: \\n2018-11-04 05:05:32,032 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing modify acls groups to: \\n2018-11-04 05:05:32,032 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - SecurityManager: authentication disabled; ui acls disabled; users  with view permissions: Set(nobody); groups with view permissions: Set(); users  with modify permissions: Set(nobody); groups with modify permissions: Set()\\n2018-11-04 05:05:32,266 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Successfully started service 'sparkDriver' on port 7077.\\n2018-11-04 05:05:32,283 INFO  [Thread-4] spark.SparkEnv (Logging.scala:logInfo(54)) - Registering MapOutputTracker\\n2018-11-04 05:05:32,300 INFO  [Thread-4] spark.SparkEnv (Logging.scala:logInfo(54)) - Registering BlockManagerMaster\\n2018-11-04 05:05:32,303 INFO  [Thread-4] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information\\n2018-11-04 05:05:32,303 INFO  [Thread-4] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - BlockManagerMasterEndpoint up\\n2018-11-04 05:05:32,311 INFO  [Thread-4] storage.DiskBlockManager (Logging.scala:logInfo(54)) - Created local directory at /mnt/mesos/sandbox/blockmgr-7a9fcb81-b361-4586-bc6b-070b1831d7fe\\n2018-11-04 05:05:32,332 INFO  [Thread-4] memory.MemoryStore (Logging.scala:logInfo(54)) - MemoryStore started with capacity 3.4 GB\\n2018-11-04 05:05:32,361 INFO  [Thread-4] metrics.MetricsConfig (Logging.scala:logInfo(54)) - Loading metrics properties from resource metrics.properties\\n2018-11-04 05:05:32,362 INFO  [Thread-4] metrics.MetricsConfig (Logging.scala:logInfo(54)) - Metrics properties: {*.sink.servlet.path=/metrics/json, applications.sink.servlet.path=/metrics/applications/json, *.sink.servlet.class=org.apache.spark.metrics.sink.MetricsServlet, master.sink.servlet.path=/metrics/master/json}\\n2018-11-04 05:05:32,369 INFO  [Thread-4] spark.SparkEnv (Logging.scala:logInfo(54)) - Registering OutputCommitCoordinator\\n2018-11-04 05:05:32,441 INFO  [Thread-4] util.log (Log.java:initialized(192)) - Logging initialized @10390ms\\n2018-11-04 05:05:32,495 INFO  [Thread-4] server.Server (Server.java:doStart(345)) - jetty-9.3.z-SNAPSHOT\\n2018-11-04 05:05:32,508 INFO  [Thread-4] server.Server (Server.java:doStart(403)) - Started @10458ms\\n2018-11-04 05:05:32,526 INFO  [Thread-4] server.AbstractConnector (AbstractConnector.java:doStart(270)) - Started ServerConnector@4c2af2bb{HTTP/1.1,[http/1.1]}{0.0.0.0:4040}\\n2018-11-04 05:05:32,526 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Successfully started service 'SparkUI' on port 4040.\\n2018-11-04 05:05:32,547 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5b64a772{/jobs,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,547 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@c326c13{/jobs/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,548 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@4172357d{/jobs/job,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,549 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3f836c5d{/jobs/job/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,549 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@6366bbf7{/stages,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,550 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3982090d{/stages/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,550 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5323d16a{/stages/stage,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,551 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@774caee7{/stages/stage/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,552 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@43358919{/stages/pool,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,552 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@274149b2{/stages/pool/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,553 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@63277d25{/storage,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,553 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3c0f4f73{/storage/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,554 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@420d6ab2{/storage/rdd,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,555 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@61b55a6a{/storage/rdd/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,555 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@d0e9570{/environment,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,556 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5ed599ad{/environment/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,556 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@7a365b53{/executors,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,557 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5a4d8c48{/executors/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,557 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@460d2aac{/executors/threadDump,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,558 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@63200c3e{/executors/threadDump/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,564 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@a9fd4a4{/static,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,564 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5b09255c{/,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,565 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@51e1b160{/api,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,566 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@56191c60{/jobs/job/kill,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,567 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3c0cb310{/stages/stage/kill,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,568 INFO  [Thread-4] ui.SparkUI (Logging.scala:logInfo(54)) - Bound SparkUI to 9.0.12.2, and started at http://9.0.12.2:4040\\n2018-11-04 05:05:32,585 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar with timestamp 1541307932585\\n2018-11-04 05:05:32,585 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar with timestamp 1541307932585\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.spark-project.spark_unused-1.0.0.jar at spark://9.0.12.2:7077/jars/org.spark-project.spark_unused-1.0.0.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar at spark://9.0.12.2:7077/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/com.yammer.metrics_metrics-core-2.2.0.jar at spark://9.0.12.2:7077/jars/com.yammer.metrics_metrics-core-2.2.0.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-log4j12-1.7.21.jar at spark://9.0.12.2:7077/jars/org.slf4j_slf4j-log4j12-1.7.21.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/com.101tec_zkclient-0.10.jar at spark://9.0.12.2:7077/jars/com.101tec_zkclient-0.10.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.zookeeper_zookeeper-3.4.9.jar at spark://9.0.12.2:7077/jars/org.apache.zookeeper_zookeeper-3.4.9.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar at spark://9.0.12.2:7077/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/net.jpountz.lz4_lz4-1.3.0.jar at spark://9.0.12.2:7077/jars/net.jpountz.lz4_lz4-1.3.0.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar at spark://9.0.12.2:7077/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-api-1.7.21.jar at spark://9.0.12.2:7077/jars/org.slf4j_slf4j-api-1.7.21.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/log4j_log4j-1.2.17.jar at spark://9.0.12.2:7077/jars/log4j_log4j-1.2.17.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,849 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py at spark://9.0.12.2:7077/files/mnist_data_setup.py with timestamp 1541307932848\\n2018-11-04 05:05:32,850 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/mnist_data_setup.py\\n2018-11-04 05:05:32,857 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar at spark://9.0.12.2:7077/files/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar with timestamp 1541307932857\\n2018-11-04 05:05:32,858 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar\\n2018-11-04 05:05:32,861 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar at spark://9.0.12.2:7077/files/org.apache.kafka_kafka_2.11-0.10.2.1.jar with timestamp 1541307932861\\n2018-11-04 05:05:32,861 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.kafka_kafka_2.11-0.10.2.1.jar\\n2018-11-04 05:05:32,869 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar at spark://9.0.12.2:7077/files/org.apache.spark_spark-tags_2.11-2.2.1.jar with timestamp 1541307932869\\n2018-11-04 05:05:32,869 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.spark_spark-tags_2.11-2.2.1.jar\\n2018-11-04 05:05:32,872 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.spark-project.spark_unused-1.0.0.jar at spark://9.0.12.2:7077/files/org.spark-project.spark_unused-1.0.0.jar with timestamp 1541307932872\\n2018-11-04 05:05:32,872 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.spark-project.spark_unused-1.0.0.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.spark-project.spark_unused-1.0.0.jar\\n2018-11-04 05:05:32,881 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar at spark://9.0.12.2:7077/files/org.apache.kafka_kafka-clients-0.10.2.1.jar with timestamp 1541307932881\\n2018-11-04 05:05:32,881 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.kafka_kafka-clients-0.10.2.1.jar\\n2018-11-04 05:05:32,885 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar at spark://9.0.12.2:7077/files/net.sf.jopt-simple_jopt-simple-5.0.3.jar with timestamp 1541307932885\\n2018-11-04 05:05:32,886 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/net.sf.jopt-simple_jopt-simple-5.0.3.jar\\n2018-11-04 05:05:32,889 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/com.yammer.metrics_metrics-core-2.2.0.jar at spark://9.0.12.2:7077/files/com.yammer.metrics_metrics-core-2.2.0.jar with timestamp 1541307932889\\n2018-11-04 05:05:32,889 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/com.yammer.metrics_metrics-core-2.2.0.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/com.yammer.metrics_metrics-core-2.2.0.jar\\n2018-11-04 05:05:32,892 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-log4j12-1.7.21.jar at spark://9.0.12.2:7077/files/org.slf4j_slf4j-log4j12-1.7.21.jar with timestamp 1541307932892\\n2018-11-04 05:05:32,892 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-log4j12-1.7.21.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.slf4j_slf4j-log4j12-1.7.21.jar\\n2018-11-04 05:05:32,895 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/com.101tec_zkclient-0.10.jar at spark://9.0.12.2:7077/files/com.101tec_zkclient-0.10.jar with timestamp 1541307932895\\n2018-11-04 05:05:32,896 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/com.101tec_zkclient-0.10.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/com.101tec_zkclient-0.10.jar\\n2018-11-04 05:05:32,899 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.zookeeper_zookeeper-3.4.9.jar at spark://9.0.12.2:7077/files/org.apache.zookeeper_zookeeper-3.4.9.jar with timestamp 1541307932899\\n2018-11-04 05:05:32,899 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.zookeeper_zookeeper-3.4.9.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.zookeeper_zookeeper-3.4.9.jar\\n2018-11-04 05:05:32,903 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar at spark://9.0.12.2:7077/files/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar with timestamp 1541307932903\\n2018-11-04 05:05:32,903 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar\\n2018-11-04 05:05:32,906 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/net.jpountz.lz4_lz4-1.3.0.jar at spark://9.0.12.2:7077/files/net.jpountz.lz4_lz4-1.3.0.jar with timestamp 1541307932906\\n2018-11-04 05:05:32,907 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/net.jpountz.lz4_lz4-1.3.0.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/net.jpountz.lz4_lz4-1.3.0.jar\\n2018-11-04 05:05:32,910 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar at spark://9.0.12.2:7077/files/org.xerial.snappy_snappy-java-1.1.2.6.jar with timestamp 1541307932910\\n2018-11-04 05:05:32,910 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.xerial.snappy_snappy-java-1.1.2.6.jar\\n2018-11-04 05:05:32,914 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-api-1.7.21.jar at spark://9.0.12.2:7077/files/org.slf4j_slf4j-api-1.7.21.jar with timestamp 1541307932914\\n2018-11-04 05:05:32,914 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-api-1.7.21.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.slf4j_slf4j-api-1.7.21.jar\\n2018-11-04 05:05:32,917 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/log4j_log4j-1.2.17.jar at spark://9.0.12.2:7077/files/log4j_log4j-1.2.17.jar with timestamp 1541307932917\\n2018-11-04 05:05:32,917 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/log4j_log4j-1.2.17.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/log4j_log4j-1.2.17.jar\\n2018-11-04 05:05:33,026 WARN  [Thread-4] metrics.MetricsSystem (Logging.scala:logWarning(66)) - Using default name mesos_cluster for source because neither spark.metrics.namespace nor spark.app.id is set.\\n2018-11-04 05:05:33,027 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: mesos_cluster\\n2018-11-04 05:05:33,168 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 43132.\\n2018-11-04 05:05:33,169 INFO  [Thread-4] netty.NettyBlockTransferService (Logging.scala:logInfo(54)) - Server created on 9.0.12.2:43132\\n2018-11-04 05:05:33,170 INFO  [Thread-4] storage.BlockManager (Logging.scala:logInfo(54)) - Using org.apache.spark.storage.RandomBlockReplicationPolicy for block replication policy\\n2018-11-04 05:05:33,172 INFO  [Thread-4] storage.BlockManagerMaster (Logging.scala:logInfo(54)) - Registering BlockManager BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,176 INFO  [dispatcher-event-loop-1] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 9.0.12.2:43132 with 3.4 GB RAM, BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,181 INFO  [Thread-4] storage.BlockManagerMaster (Logging.scala:logInfo(54)) - Registered BlockManager BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,182 INFO  [Thread-4] storage.BlockManager (Logging.scala:logInfo(54)) - Initialized BlockManager: BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,184 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.CodeGenerator\\n2018-11-04 05:05:33,184 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.HiveExternalCatalog\\n2018-11-04 05:05:33,186 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Initializing sink: org.apache.spark.metrics.sink.MetricsServlet\\n2018-11-04 05:05:33,344 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@159ad6ad{/metrics/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:35,103 INFO  [Thread-35] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 0 is now TASK_STARTING\\n2018-11-04 05:05:35,107 INFO  [Thread-36] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 0 is now TASK_RUNNING\\n2018-11-04 05:05:35,181 INFO  [Thread-37] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 1 is now TASK_STARTING\\n2018-11-04 05:05:35,184 INFO  [Thread-38] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 1 is now TASK_RUNNING\\n2018-11-04 05:05:35,298 INFO  [Thread-39] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 3 is now TASK_STARTING\\n2018-11-04 05:05:35,301 INFO  [Thread-40] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 3 is now TASK_RUNNING\\n2018-11-04 05:05:35,375 INFO  [Thread-41] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 2 is now TASK_STARTING\\n2018-11-04 05:05:35,379 INFO  [Thread-42] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 2 is now TASK_RUNNING\\n2018-11-04 05:05:35,388 INFO  [Thread-43] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 4 is now TASK_STARTING\\n2018-11-04 05:05:35,391 INFO  [Thread-44] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 4 is now TASK_RUNNING\\n2018-11-04 05:05:38,780 INFO  [dispatcher-event-loop-0] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.12:49318) with ID 1\\n2018-11-04 05:05:38,820 INFO  [dispatcher-event-loop-1] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.5.21:41167 with 3.4 GB RAM, BlockManagerId(1, 10.0.5.21, 41167, None)\\n2018-11-04 05:05:38,869 INFO  [dispatcher-event-loop-2] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.10:49670) with ID 0\\n2018-11-04 05:05:38,877 INFO  [dispatcher-event-loop-1] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.16:59356) with ID 3\\n2018-11-04 05:05:38,906 INFO  [dispatcher-event-loop-2] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.6.159:33911 with 3.4 GB RAM, BlockManagerId(0, 10.0.6.159, 33911, None)\\n2018-11-04 05:05:38,914 INFO  [dispatcher-event-loop-2] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.6.242:35839 with 3.4 GB RAM, BlockManagerId(3, 10.0.6.242, 35839, None)\\n2018-11-04 05:05:38,944 INFO  [dispatcher-event-loop-0] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.7:58360) with ID 2\\n2018-11-04 05:05:38,980 INFO  [dispatcher-event-loop-1] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.4.250:37259 with 3.4 GB RAM, BlockManagerId(2, 10.0.4.250, 37259, None)\\n2018-11-04 05:05:39,013 INFO  [dispatcher-event-loop-2] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.9:36692) with ID 4\\n2018-11-04 05:05:39,081 INFO  [dispatcher-event-loop-0] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.5.82:39721 with 3.4 GB RAM, BlockManagerId(4, 10.0.5.82, 39721, None)\\n2018-11-04 05:05:39,103 INFO  [Thread-4] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 1.0\\n2018-11-04 05:05:39,104 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.DAGScheduler\\n2018-11-04 05:05:39,108 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.BlockManager\\nWARNING:tensorflow:From /mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py:48: extract_images (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.\\nInstructions for updating:\\nPlease use tf.data to implement this functionality.\\nExtracting mnist/train-images-idx3-ubyte.gz\\nWARNING:tensorflow:From /mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py:52: extract_labels (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.\\nInstructions for updating:\\nPlease use tf.data to implement this functionality.\\nExtracting mnist/train-labels-idx1-ubyte.gz\\nimages.shape: (60000, 28, 28, 1)\\nlabels.shape: (60000,)\\n2018-11-04 05:05:40,799 INFO  [Thread-4] deploy.SparkHadoopUtil (Logging.scala:logInfo(54)) - Adding user credentials: List()\\n2018-11-04 05:05:40,871 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(123)) - File Output Committer Algorithm version is 1\\n2018-11-04 05:05:40,871 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(138)) - FileOutputCommitter skip cleanup _temporary folders under output directory:false, ignore cleanup failures: false\\n2018-11-04 05:05:40,974 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Starting job: saveAsTextFile at NativeMethodAccessorImpl.java:0\\n2018-11-04 05:05:40,984 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Got job 0 (saveAsTextFile at NativeMethodAccessorImpl.java:0) with 10 output partitions\\n2018-11-04 05:05:40,984 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Final stage: ResultStage 0 (saveAsTextFile at NativeMethodAccessorImpl.java:0)\\n2018-11-04 05:05:40,985 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Parents of final stage: List()\\n2018-11-04 05:05:40,986 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Missing parents: List()\\n2018-11-04 05:05:40,995 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting ResultStage 0 (MapPartitionsRDD[7] at saveAsTextFile at NativeMethodAccessorImpl.java:0), which has no missing parents\\n2018-11-04 05:05:41,117 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_0 stored as values in memory (estimated size 176.1 KB, free 3.4 GB)\\n2018-11-04 05:05:41,150 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_0_piece0 stored as bytes in memory (estimated size 55.3 KB, free 3.4 GB)\\n2018-11-04 05:05:41,152 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 9.0.12.2:43132 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:41,154 INFO  [dag-scheduler-event-loop] spark.SparkContext (Logging.scala:logInfo(54)) - Created broadcast 0 from broadcast at DAGScheduler.scala:1006\\n2018-11-04 05:05:41,164 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting 10 missing tasks from ResultStage 0 (MapPartitionsRDD[7] at saveAsTextFile at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))\\n2018-11-04 05:05:41,173 INFO  [dag-scheduler-event-loop] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Adding task set 0.0 with 10 tasks\\n2018-11-04 05:05:41,205 WARN  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logWarning(66)) - Stage 0 contains a task of very large size (4299 KB). The maximum recommended task size is 100 KB.\\n2018-11-04 05:05:41,206 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 0.0 in stage 0.0 (TID 0, 10.0.6.159, executor 0, partition 0, PROCESS_LOCAL, 4402486 bytes)\\n2018-11-04 05:05:41,213 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 1.0 in stage 0.0 (TID 1, 10.0.4.250, executor 2, partition 1, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:41,229 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 2.0 in stage 0.0 (TID 2, 10.0.5.21, executor 1, partition 2, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:41,234 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 3.0 in stage 0.0 (TID 3, 10.0.5.82, executor 4, partition 3, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:41,241 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 4.0 in stage 0.0 (TID 4, 10.0.6.242, executor 3, partition 4, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:42,609 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.6.242:35839 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,656 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.4.250:37259 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,879 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.6.159:33911 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,890 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.5.21:41167 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,891 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.5.82:39721 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:48,873 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 5.0 in stage 0.0 (TID 5, 10.0.6.159, executor 0, partition 5, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:48,876 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 0.0 in stage 0.0 (TID 0) in 7686 ms on 10.0.6.159 (executor 0) (1/10)\\n2018-11-04 05:05:49,385 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 6.0 in stage 0.0 (TID 6, 10.0.5.82, executor 4, partition 6, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:49,386 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 3.0 in stage 0.0 (TID 3) in 8157 ms on 10.0.5.82 (executor 4) (2/10)\\n2018-11-04 05:05:49,469 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 7.0 in stage 0.0 (TID 7, 10.0.5.21, executor 1, partition 7, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:49,470 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 2.0 in stage 0.0 (TID 2) in 8256 ms on 10.0.5.21 (executor 1) (3/10)\\n2018-11-04 05:05:49,565 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 8.0 in stage 0.0 (TID 8, 10.0.4.250, executor 2, partition 8, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:49,566 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 1.0 in stage 0.0 (TID 1) in 8359 ms on 10.0.4.250 (executor 2) (4/10)\\n2018-11-04 05:05:49,859 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 9.0 in stage 0.0 (TID 9, 10.0.6.242, executor 3, partition 9, PROCESS_LOCAL, 4924188 bytes)\\n2018-11-04 05:05:49,859 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 4.0 in stage 0.0 (TID 4) in 8625 ms on 10.0.6.242 (executor 3) (5/10)\\n2018-11-04 05:05:53,239 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 5.0 in stage 0.0 (TID 5) in 4373 ms on 10.0.6.159 (executor 0) (6/10)\\n2018-11-04 05:05:53,837 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 9.0 in stage 0.0 (TID 9) in 3983 ms on 10.0.6.242 (executor 3) (7/10)\\n2018-11-04 05:05:53,848 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 7.0 in stage 0.0 (TID 7) in 4384 ms on 10.0.5.21 (executor 1) (8/10)\\n2018-11-04 05:05:53,859 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 6.0 in stage 0.0 (TID 6) in 4484 ms on 10.0.5.82 (executor 4) (9/10)\\n2018-11-04 05:05:54,046 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 8.0 in stage 0.0 (TID 8) in 4485 ms on 10.0.4.250 (executor 2) (10/10)\\n2018-11-04 05:05:54,047 INFO  [task-result-getter-1] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Removed TaskSet 0.0, whose tasks have all completed, from pool \\n2018-11-04 05:05:54,048 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - ResultStage 0 (saveAsTextFile at NativeMethodAccessorImpl.java:0) finished in 12.861 s\\n2018-11-04 05:05:54,053 INFO  [Thread-4] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Job 0 finished: saveAsTextFile at NativeMethodAccessorImpl.java:0, took 13.077980 s\\n2018-11-04 05:05:54,262 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 9.0.12.2:43132 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,266 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.6.242:35839 in memory (size: 55.3 KB, free: 3.4 GB)\\nExtracting mnist/t10k-images-idx3-ubyte.gz\\n2018-11-04 05:05:54,333 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.4.250:37259 in memory (size: 55.3 KB, free: 3.4 GB)\\nExtracting mnist/t10k-labels-idx1-ubyte.gz\\nimages.shape: (10000, 28, 28, 1)\\nlabels.shape: (10000,)\\n2018-11-04 05:05:54,343 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.5.21:41167 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,347 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.6.159:33911 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,347 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.5.82:39721 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,493 INFO  [Thread-4] deploy.SparkHadoopUtil (Logging.scala:logInfo(54)) - Adding user credentials: List()\\n2018-11-04 05:05:54,495 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(123)) - File Output Committer Algorithm version is 1\\n2018-11-04 05:05:54,495 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(138)) - FileOutputCommitter skip cleanup _temporary folders under output directory:false, ignore cleanup failures: false\\n2018-11-04 05:05:54,513 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Starting job: saveAsTextFile at NativeMethodAccessorImpl.java:0\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Got job 1 (saveAsTextFile at NativeMethodAccessorImpl.java:0) with 10 output partitions\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Final stage: ResultStage 1 (saveAsTextFile at NativeMethodAccessorImpl.java:0)\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Parents of final stage: List()\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Missing parents: List()\\n2018-11-04 05:05:54,515 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting ResultStage 1 (MapPartitionsRDD[15] at saveAsTextFile at NativeMethodAccessorImpl.java:0), which has no missing parents\\n2018-11-04 05:05:54,529 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_1 stored as values in memory (estimated size 176.1 KB, free 3.4 GB)\\n2018-11-04 05:05:54,532 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_1_piece0 stored as bytes in memory (estimated size 55.3 KB, free 3.4 GB)\\n2018-11-04 05:05:54,532 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 9.0.12.2:43132 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,533 INFO  [dag-scheduler-event-loop] spark.SparkContext (Logging.scala:logInfo(54)) - Created broadcast 1 from broadcast at DAGScheduler.scala:1006\\n2018-11-04 05:05:54,534 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting 10 missing tasks from ResultStage 1 (MapPartitionsRDD[15] at saveAsTextFile at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))\\n2018-11-04 05:05:54,534 INFO  [dag-scheduler-event-loop] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Adding task set 1.0 with 10 tasks\\n2018-11-04 05:05:54,535 WARN  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logWarning(66)) - Stage 1 contains a task of very large size (843 KB). The maximum recommended task size is 100 KB.\\n2018-11-04 05:05:54,535 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 0.0 in stage 1.0 (TID 10, 10.0.5.21, executor 1, partition 0, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,536 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 1.0 in stage 1.0 (TID 11, 10.0.5.82, executor 4, partition 1, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,537 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 2.0 in stage 1.0 (TID 12, 10.0.6.159, executor 0, partition 2, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,538 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 3.0 in stage 1.0 (TID 13, 10.0.6.242, executor 3, partition 3, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,539 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 4.0 in stage 1.0 (TID 14, 10.0.4.250, executor 2, partition 4, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,579 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.5.82:39721 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,582 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.6.242:35839 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,600 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.4.250:37259 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,643 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.5.21:41167 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,676 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.6.159:33911 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:55,350 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 5.0 in stage 1.0 (TID 15, 10.0.4.250, executor 2, partition 5, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,351 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 4.0 in stage 1.0 (TID 14) in 813 ms on 10.0.4.250 (executor 2) (1/10)\\n2018-11-04 05:05:55,353 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 6.0 in stage 1.0 (TID 16, 10.0.5.82, executor 4, partition 6, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,354 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 1.0 in stage 1.0 (TID 11) in 818 ms on 10.0.5.82 (executor 4) (2/10)\\n2018-11-04 05:05:55,566 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 7.0 in stage 1.0 (TID 17, 10.0.6.159, executor 0, partition 7, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,566 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 2.0 in stage 1.0 (TID 12) in 1030 ms on 10.0.6.159 (executor 0) (3/10)\\n2018-11-04 05:05:55,850 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 8.0 in stage 1.0 (TID 18, 10.0.5.21, executor 1, partition 8, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,850 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 0.0 in stage 1.0 (TID 10) in 1315 ms on 10.0.5.21 (executor 1) (4/10)\\n2018-11-04 05:05:55,870 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 9.0 in stage 1.0 (TID 19, 10.0.6.242, executor 3, partition 9, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,870 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 3.0 in stage 1.0 (TID 13) in 1333 ms on 10.0.6.242 (executor 3) (5/10)\\n2018-11-04 05:05:56,243 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 6.0 in stage 1.0 (TID 16) in 891 ms on 10.0.5.82 (executor 4) (6/10)\\n2018-11-04 05:05:56,243 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 5.0 in stage 1.0 (TID 15) in 894 ms on 10.0.4.250 (executor 2) (7/10)\\n2018-11-04 05:05:56,371 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 7.0 in stage 1.0 (TID 17) in 806 ms on 10.0.6.159 (executor 0) (8/10)\\n2018-11-04 05:05:56,760 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 8.0 in stage 1.0 (TID 18) in 911 ms on 10.0.5.21 (executor 1) (9/10)\\n2018-11-04 05:05:56,762 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 9.0 in stage 1.0 (TID 19) in 893 ms on 10.0.6.242 (executor 3) (10/10)\\n2018-11-04 05:05:56,762 INFO  [task-result-getter-3] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Removed TaskSet 1.0, whose tasks have all completed, from pool \\n2018-11-04 05:05:56,763 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - ResultStage 1 (saveAsTextFile at NativeMethodAccessorImpl.java:0) finished in 2.229 s\\n2018-11-04 05:05:56,763 INFO  [Thread-4] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Job 1 finished: saveAsTextFile at NativeMethodAccessorImpl.java:0, took 2.250033 s\\n2018-11-04 05:05:57,278 INFO  [pool-7-thread-1] spark.SparkContext (Logging.scala:logInfo(54)) - Invoking stop() from shutdown hook\\n2018-11-04 05:05:57,283 INFO  [pool-7-thread-1] server.AbstractConnector (AbstractConnector.java:doStop(310)) - Stopped Spark@4c2af2bb{HTTP/1.1,[http/1.1]}{9.0.12.2:4040}\\n2018-11-04 05:05:57,284 INFO  [pool-7-thread-1] ui.SparkUI (Logging.scala:logInfo(54)) - Stopped Spark web UI at http://9.0.12.2:4040\\n2018-11-04 05:05:57,289 INFO  [pool-7-thread-1] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Shutting down all executors\\n2018-11-04 05:05:57,289 INFO  [dispatcher-event-loop-2] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Asking each executor to shut down\\n2018-11-04 05:05:57,861 INFO  [Thread-52] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 0 is now TASK_FINISHED\\n2018-11-04 05:05:57,946 INFO  [Thread-54] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 2 is now TASK_FINISHED\\n2018-11-04 05:05:57,956 INFO  [Thread-56] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 1 is now TASK_FINISHED\\n2018-11-04 05:05:57,962 INFO  [Thread-58] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 4 is now TASK_FINISHED\\n2018-11-04 05:05:57,965 INFO  [Thread-59] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 3 is now TASK_FINISHED\\n2018-11-04 05:05:57,995 INFO  [MesosCoarseGrainedSchedulerBackend-mesos-driver] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - driver.run() returned with code DRIVER_STOPPED\\n2018-11-04 05:05:57,999 INFO  [dispatcher-event-loop-0] spark.MapOutputTrackerMasterEndpoint (Logging.scala:logInfo(54)) - MapOutputTrackerMasterEndpoint stopped!\\n2018-11-04 05:05:58,003 INFO  [pool-7-thread-1] memory.MemoryStore (Logging.scala:logInfo(54)) - MemoryStore cleared\\n2018-11-04 05:05:58,003 INFO  [pool-7-thread-1] storage.BlockManager (Logging.scala:logInfo(54)) - BlockManager stopped\\n2018-11-04 05:05:58,004 INFO  [pool-7-thread-1] storage.BlockManagerMaster (Logging.scala:logInfo(54)) - BlockManagerMaster stopped\\n2018-11-04 05:05:58,006 INFO  [dispatcher-event-loop-1] scheduler.OutputCommitCoordinator$OutputCommitCoordinatorEndpoint (Logging.scala:logInfo(54)) - OutputCommitCoordinator stopped!\\n2018-11-04 05:05:58,009 INFO  [pool-7-thread-1] spark.SparkContext (Logging.scala:logInfo(54)) - Successfully stopped SparkContext\\n2018-11-04 05:05:58,009 INFO  [pool-7-thread-1] util.ShutdownHookManager (Logging.scala:logInfo(54)) - Shutdown hook called\\n2018-11-04 05:05:58,010 INFO  [pool-7-thread-1] util.ShutdownHookManager (Logging.scala:logInfo(54)) - Deleting directory /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/pyspark-0a69328c-1da5-4d8b-b627-a57622638e05\\n2018-11-04 05:05:58,010 INFO  [pool-7-thread-1] util.ShutdownHookManager (Logging.scala:logInfo(54)) - Deleting directory /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a\\n\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create mnist data in csv2 format\n",
+    "subprocess.check_output('eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2', shell=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_StoreTrueAction(option_strings=['--tensorboard'], dest='tensorboard', nargs=0, const=True, default=False, type=None, choices=None, help='launch tensorboard process', metavar=None)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "num_ps = 0\n",
+    "num_executors = 5\n",
+    "\n",
+    "parser = argparse.ArgumentParser()\n",
+    "parser.add_argument(\"--batch_size\", help=\"number of records per batch\", type=int, default=100)\n",
+    "parser.add_argument(\"--cluster_size\", help=\"number of nodes in the cluster (for Spark Standalone)\", type=int, default=num_executors)\n",
+    "parser.add_argument(\"--driver_ps_nodes\", help=\"\"\"run tensorflow PS node on driver locally.\n",
+    "    You will need to set cluster_size = num_executors + num_ps\"\"\", default=False)\n",
+    "parser.add_argument(\"--epochs\", help=\"number of epochs\", type=int, default=1)\n",
+    "parser.add_argument(\"--format\", help=\"example format: (csv2|tfr)\", choices=[\"csv2\", \"tfr\"], default=\"tfr\")\n",
+    "parser.add_argument(\"--images_labels\", help=\"HDFS path to MNIST image_label files in parallelized format\")\n",
+    "parser.add_argument(\"--mode\", help=\"train|inference\", default=\"train\")\n",
+    "parser.add_argument(\"--model\", help=\"HDFS path to save/load model during train/test\", default=\"mnist_model\")\n",
+    "parser.add_argument(\"--num_ps\", help=\"number of ps nodes\", default=num_ps)\n",
+    "parser.add_argument(\"--output\", help=\"HDFS path to save test/inference output\", default=\"predictions\")\n",
+    "parser.add_argument(\"--rdma\", help=\"use rdma connection\", default=False)\n",
+    "parser.add_argument(\"--readers\", help=\"number of reader/enqueue threads per worker\", type=int, default=10)\n",
+    "parser.add_argument(\"--shuffle_size\", help=\"size of shuffle buffer\", type=int, default=1000)\n",
+    "parser.add_argument(\"--steps\", help=\"maximum number of steps\", type=int, default=500)\n",
+    "parser.add_argument(\"--tensorboard\", help=\"launch tensorboard process\", action=\"store_true\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "# CPU Config\n",
-    "conf = SparkConf().setAppName('Mnist') \\\n",
-    "                  .set('spark.mesos.executor.docker.image', 'mesosphere/mesosphere-data-toolkit:latest') \n"
+    "# # CPU Config\n",
+    "# conf = SparkConf().setAppName('Mnist-CPU') \\\n",
+    "#                   .set('spark.mesos.executor.docker.image', 'fabianbaier/data-toolkit:latest-gpu') \n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
     "# GPU Config\n",
-    "#conf = SparkConf().setAppName('Mnist-GPU') \\\n",
-    "#                  .set('spark.mesos.executor.docker.image', 'mesosphere/mesosphere-data-toolkit:latest-gpu') \\\n",
-    "#                  .set('spark.mesos.gpus.max', 5) \\\n",
-    "#                  .set('spark.mesos.executor.gpus', 1)"
+    "conf = SparkConf().setAppName('Mnist-GPU') \\\n",
+    "                 .set('spark.mesos.executor.docker.image', 'mesosphere/mesosphere-data-toolkit:latest-gpu') \\\n",
+    "                 .set('spark.mesos.gpus.max', num_executors) \\\n",
+    "                 .set('spark.mesos.executor.gpus', 1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception in thread Thread-4:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/conda/lib/python3.6/threading.py\", line 916, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 117, in run\n",
+      "    self.onrecv(msg)\n",
+      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 134, in onrecv\n",
+      "    \"msg\": msg\n",
+      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 214, in sendToFrontEnd\n",
+      "    monitor.send(msg)\n",
+      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 51, in send\n",
+      "    self.comm.send(msg)\n",
+      "AttributeError: 'ScalaMonitor' object has no attribute 'comm'\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
+    "# Make sure you cloned the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark : git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark\n",
     "sc = SparkContext(conf=conf).getOrCreate()\n",
-    "sc.addPyFile('TensorFlowOnSpark/examples/mnist/spark/mnist_dist.py')"
+    "sc.addPyFile('tensorflowonspark/examples/mnist/tf/mnist_dist.py')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "scrolled": true
    },
@@ -75,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -87,128 +237,186 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'-rw-r--r--   3 nobody supergroup          0 2018-11-04 05:05 mnist/csv2/train/_SUCCESS\\n-rw-r--r--   3 nobody supergroup    9348476 2018-11-04 05:05 mnist/csv2/train/part-00000\\n-rw-r--r--   3 nobody supergroup   11244092 2018-11-04 05:05 mnist/csv2/train/part-00001\\n-rw-r--r--   3 nobody supergroup   11227072 2018-11-04 05:05 mnist/csv2/train/part-00002\\n-rw-r--r--   3 nobody supergroup   11238388 2018-11-04 05:05 mnist/csv2/train/part-00003\\n-rw-r--r--   3 nobody supergroup   11225055 2018-11-04 05:05 mnist/csv2/train/part-00004\\n-rw-r--r--   3 nobody supergroup   11186122 2018-11-04 05:05 mnist/csv2/train/part-00005\\n-rw-r--r--   3 nobody supergroup   11226573 2018-11-04 05:05 mnist/csv2/train/part-00006\\n-rw-r--r--   3 nobody supergroup   11213312 2018-11-04 05:05 mnist/csv2/train/part-00007\\n-rw-r--r--   3 nobody supergroup   11206429 2018-11-04 05:05 mnist/csv2/train/part-00008\\n-rw-r--r--   3 nobody supergroup   10460475 2018-11-04 05:05 mnist/csv2/train/part-00009\\n'\n"
+     ]
+    }
+   ],
    "source": [
-    "parser = argparse.ArgumentParser()\n",
-    "parser.add_argument(\"--epochs\", help=\"number of epochs\", type=int, default=1)\n",
-    "parser.add_argument(\"--images\", help=\"HDFS path to MNIST images in parallelized format\")\n",
-    "parser.add_argument(\"--labels\", help=\"HDFS path to MNIST labels in parallelized format\")\n",
-    "parser.add_argument(\"--format\", help=\"example format\", choices=[\"csv\",\"pickle\",\"tfr\"], default=\"csv\")\n",
-    "parser.add_argument(\"--model\", help=\"HDFS path to save/load model during train/test\", default=\"mnist/mnist_csv_model\")\n",
-    "parser.add_argument(\"--export_dir\", help=\"HDFS path to export saved_model\", default=\"mnist/mnist_export\")\n",
-    "parser.add_argument(\"--readers\", help=\"number of reader/enqueue threads\", type=int, default=1)\n",
-    "parser.add_argument(\"--steps\", help=\"maximum number of steps\", type=int, default=500)\n",
-    "parser.add_argument(\"--batch_size\", help=\"number of examples per batch\", type=int, default=100)\n",
-    "parser.add_argument(\"--mode\", help=\"train|inference\", default=\"train\")\n",
-    "parser.add_argument(\"--rdma\", help=\"use rdma connection\", default=False)\n",
-    "num_executors = 5"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "#remove existing models if any\n",
-    "subprocess.check_output(shlex.split('hdfs dfs -rm -R -f -skipTrash mnist/mnist_csv_model'))\n",
-    "subprocess.check_output(shlex.split('hdfs dfs -rm -R -f -skipTrash mnist/mnist_export'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "#verify training images\n",
-    "train_images_files = \"mnist/csv/train/images\"\n",
+    "# Verify training images\n",
+    "# Make sure you unzipped mnist.zip into mnist and ran the mnist_data_setup job via: eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2\n",
+    "train_images_files = \"mnist/csv2/train\"\n",
     "print(subprocess.check_output(shlex.split('hdfs dfs -ls -R {}'.format(train_images_files))))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=1, format='csv2', images_labels='mnist/csv2/train', mode='train', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
+     ]
+    }
+   ],
    "source": [
-    "#verify training labels\n",
-    "train_labels_files = \"mnist/csv/train/labels\"\n",
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls -R {}'.format(train_labels_files))))"
+    "# Parse arguments for training\n",
+    "args = parser.parse_args(['--mode', 'train', '--epochs', '1',\n",
+    "                          '--batch_size', '100',\n",
+    "                          '--images_labels', train_images_files,\n",
+    "                          '--format', 'csv2',\n",
+    "                          '--steps', '10000',\n",
+    "                          '--model', 'mnist_model'])\n",
+    "print(args)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:07:01 INFO:Reserving TFSparkNodes \n",
+      "05:07:01 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
+      "05:07:01 INFO:listening for reservations at ('9.0.12.2', 35255)\n",
+      "05:07:01 INFO:Starting TensorFlow on executors\n",
+      "05:07:01 INFO:Waiting for TFSparkNodes to start\n",
+      "05:07:01 INFO:waiting for 5 reservations\n",
+      "05:07:02 INFO:waiting for 5 reservations\n",
+      "05:07:03 INFO:waiting for 5 reservations\n",
+      "05:07:04 INFO:waiting for 5 reservations\n",
+      "05:07:05 INFO:waiting for 1 reservations\n",
+      "05:07:06 INFO:all reservations completed\n",
+      "05:07:06 INFO:All TFSparkNodes started\n",
+      "05:07:06 INFO:{'executor_id': 4, 'host': '10.0.6.118', 'job_name': 'worker', 'task_index': 4, 'port': 43123, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-591qn8pd/listener-z59lcb98', 'authkey': b'\\xe3\\xcb\\xc1-Q\\x80M!\\xa7\\xbe\\xa3C\\x95C\\x0er'}\n",
+      "05:07:06 INFO:{'executor_id': 3, 'host': '10.0.5.40', 'job_name': 'worker', 'task_index': 3, 'port': 32770, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1ncu13a7/listener-ro2yft2p', 'authkey': b'\\x84aI\\xd9\\xf0\\x1aKM\\xaf\\x92?\\x88\\x17\\x1a\\x96/'}\n",
+      "05:07:06 INFO:{'executor_id': 2, 'host': '10.0.5.175', 'job_name': 'worker', 'task_index': 2, 'port': 40772, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-jj2_aw_q/listener-afcmqavz', 'authkey': b\"\\xc7z\\xbd>\\x10\\xd2H\\xb6\\x97:'\\x16\\xb3\\x19\\xe5\\xdf\"}\n",
+      "05:07:06 INFO:{'executor_id': 0, 'host': '10.0.6.30', 'job_name': 'worker', 'task_index': 0, 'port': 44873, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1wrbq0ss/listener-klxyu15s', 'authkey': b'\\x86\\x1e\\xe6&\\xf8/G\\xec\\xbbqf\\x84jOx\\x8f'}\n",
+      "05:07:06 INFO:{'executor_id': 1, 'host': '10.0.5.174', 'job_name': 'worker', 'task_index': 1, 'port': 36186, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-7m9dvgp3/listener-bfj94q8v', 'authkey': b'U\\x1d\\xf8\\xba\\xb7\\xca@#\\x86t\\xd9d\\xe1\\xbcH\\xc8'}\n"
+     ]
+    }
+   ],
    "source": [
-    "#Parse arguments for training\n",
-    "args = parser.parse_args(['--mode', 'train', '--steps', '3000', '--epochs', '5',\n",
-    "                          '--images', train_images_files, \n",
-    "                          '--labels', train_labels_files])"
+    "# Start the cluster for training\n",
+    "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, args.num_ps, False, TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
-   "source": [
-    "#start the cluster for training\n",
-    "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, num_executors, 1, False, TFCluster.InputMode.SPARK)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "#Feed data via Spark RDD\n",
-    "images = sc.textFile(args.images).map(lambda ln: [int(x) for x in ln.split(',')])\n",
-    "labels = sc.textFile(args.labels).map(lambda ln: [float(x) for x in ln.split(',')])\n",
-    "dataRDD = images.zip(labels)\n",
-    "cluster.train(dataRDD, args.epochs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:08:41 INFO:Stopping TensorFlow nodes\n",
+      "05:08:41 INFO:Shutting down cluster\n"
+     ]
+    }
+   ],
    "source": [
     "cluster.shutdown()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'Found 10 items\\n-rw-r--r--   3 nobody supergroup        128 2018-11-04 05:07 mnist_model/checkpoint\\n-rw-r--r--   3 nobody supergroup         40 2018-11-04 05:07 mnist_model/events.out.tfevents.1541308031.ip-10-0-6-30.us-west-2.compute.internal\\n-rw-r--r--   3 nobody supergroup     611832 2018-11-04 05:07 mnist_model/graph.pbtxt\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-04 05:07 mnist_model/model.ckpt-0.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-04 05:07 mnist_model/model.ckpt-0.index\\n-rw-r--r--   3 nobody supergroup     178697 2018-11-04 05:07 mnist_model/model.ckpt-0.meta\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-04 05:07 mnist_model/model.ckpt-120.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-04 05:07 mnist_model/model.ckpt-120.index\\n-rw-r--r--   3 nobody supergroup     178697 2018-11-04 05:07 mnist_model/model.ckpt-120.meta\\ndrwxr-xr-x   - nobody supergroup          0 2018-11-04 05:07 mnist_model/train\\n'\n"
+     ]
+    }
+   ],
    "source": [
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls mnist/mnist_csv_model')))\n",
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls mnist/mnist_export')))"
+    "# See if mnist_model was successfully created\n",
+    "print(subprocess.check_output(shlex.split('hdfs dfs -ls mnist_model')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=1, format='csv2', images_labels='mnist/csv2/train', mode='inference', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parse arguments for inference\n",
+    "args = parser.parse_args(['--mode', 'inference', '--epochs', '1',\n",
+    "                          '--batch_size', '100',\n",
+    "                          '--images_labels', train_images_files,\n",
+    "                          '--format', 'csv2',\n",
+    "                          '--steps', '10000',\n",
+    "                          '--output', 'predictions',\n",
+    "                          '--model', 'mnist_model'])\n",
+    "print(args)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:08:59 INFO:Reserving TFSparkNodes \n",
+      "05:08:59 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
+      "05:08:59 INFO:listening for reservations at ('9.0.12.2', 39571)\n",
+      "05:08:59 INFO:Starting TensorFlow on executors\n",
+      "05:08:59 INFO:Waiting for TFSparkNodes to start\n",
+      "05:08:59 INFO:waiting for 5 reservations\n",
+      "05:09:00 INFO:waiting for 5 reservations\n",
+      "05:09:01 INFO:all reservations completed\n",
+      "05:09:01 INFO:All TFSparkNodes started\n",
+      "05:09:01 INFO:{'executor_id': 0, 'host': '10.0.5.174', 'job_name': 'worker', 'task_index': 0, 'port': 41609, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-4bqua8ry/listener-91eahqme', 'authkey': b'\\xb5g\\xef+\\x9e_E\\xf4\\x9ap\\xc9M\\xc5\\x02\\xe8\\xc3'}\n",
+      "05:09:01 INFO:{'executor_id': 3, 'host': '10.0.6.118', 'job_name': 'worker', 'task_index': 3, 'port': 35141, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-77vqqli_/listener-p771rtqc', 'authkey': b'\\xd8=\\xf4G\\x92\\xfdD\\xf3\\x99\\x17\\xc1\\xe1Y \\xba\\x1c'}\n",
+      "05:09:01 INFO:{'executor_id': 1, 'host': '10.0.5.175', 'job_name': 'worker', 'task_index': 1, 'port': 44574, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-kqr9hebd/listener-qdjrch5x', 'authkey': b'\\x82\\xf0\\x1b\\xb7o\\x0cE\\xbb\\x8cK\\x06\\xae\\xca6\\x19\\x94'}\n",
+      "05:09:01 INFO:{'executor_id': 2, 'host': '10.0.6.30', 'job_name': 'worker', 'task_index': 2, 'port': 46388, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-jr7vqwwm/listener-glpojvcl', 'authkey': b'\\xb3k\\xb7+J\\x95D*\\xa8;\\x7ff\\x1dR\\xb6\\x13'}\n",
+      "05:09:01 INFO:{'executor_id': 4, 'host': '10.0.5.40', 'job_name': 'worker', 'task_index': 4, 'port': 46572, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1lxyryy5/listener-_3zvctj1', 'authkey': b'\\x1e\\xf4C\\x04\\x82\\x82N\\xf6\\xb8B[\\xe7\\xcb\\x0c\\x1bT'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Start the cluster for inference\n",
+    "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, args.num_ps, False, TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)"
    ]
   },
   {
@@ -219,9 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "#verify test images\n",
-    "test_images_files = \"mnist/csv/test/images\"\n",
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls {}'.format(test_images_files))))"
+    "predictions = sc.textFile(\"predictions\")"
    ]
   },
   {
@@ -232,52 +438,7 @@
    },
    "outputs": [],
    "source": [
-    "#verify test labels\n",
-    "test_labels_files = \"mnist/csv/test/labels\"\n",
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls {}'.format(test_labels_files))))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "#Parse arguments for inference\n",
-    "args = parser.parse_args(['--mode', 'inference', \n",
-    "                          '--images', test_images_files, \n",
-    "                          '--labels', test_labels_files])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "#Start the cluster for inference\n",
-    "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, num_executors, 1, False, TFCluster.InputMode.SPARK)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "#prepare data as Spark RDD\n",
-    "images = sc.textFile(args.images).map(lambda ln: [int(x) for x in ln.split(',')])\n",
-    "labels = sc.textFile(args.labels).map(lambda ln: [float(x) for x in ln.split(',')])\n",
-    "dataRDD = images.zip(labels)\n",
-    "#feed data for inference\n",
-    "prediction_results = cluster.inference(dataRDD)\n",
-    "prediction_results.take(20)"
+    "predictions.take(10)"
    ]
   },
   {

--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -71,18 +71,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "_StoreTrueAction(option_strings=['--tensorboard'], dest='tensorboard', nargs=0, const=True, default=False, type=None, choices=None, help='launch tensorboard process', metavar=None)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Set the number of executors to the number of available GPU agents\n",
     "num_ps = 0\n",
@@ -177,15 +166,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "b'-rw-r--r--   3 nobody supergroup          0 2018-11-05 22:25 mnist/tfr/train/_SUCCESS\\n-rw-r--r--   3 nobody supergroup    4865957 2018-11-05 22:25 mnist/tfr/train/part-r-00000\\n-rw-r--r--   3 nobody supergroup    5853920 2018-11-05 22:25 mnist/tfr/train/part-r-00001\\n-rw-r--r--   3 nobody supergroup    5844694 2018-11-05 22:25 mnist/tfr/train/part-r-00002\\n-rw-r--r--   3 nobody supergroup    5851485 2018-11-05 22:25 mnist/tfr/train/part-r-00003\\n-rw-r--r--   3 nobody supergroup    5844411 2018-11-05 22:25 mnist/tfr/train/part-r-00004\\n-rw-r--r--   3 nobody supergroup    5824177 2018-11-05 22:25 mnist/tfr/train/part-r-00005\\n-rw-r--r--   3 nobody supergroup    5843674 2018-11-05 22:25 mnist/tfr/train/part-r-00006\\n-rw-r--r--   3 nobody supergroup    5835612 2018-11-05 22:25 mnist/tfr/train/part-r-00007\\n-rw-r--r--   3 nobody supergroup    5833012 2018-11-05 22:25 mnist/tfr/train/part-r-00008\\n-rw-r--r--   3 nobody supergroup    5444489 2018-11-05 22:25 mnist/tfr/train/part-r-00009\\n'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Verify training images\n",
     "# Make sure you unzipped mnist.zip into mnist and ran the mnist_data_setup job via: eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2\n",
@@ -199,15 +180,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=3, format='tfr', images_labels='mnist/tfr/train', mode='train', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Parse arguments for training\n",
     "args = parser.parse_args(['--mode', 'train', '--epochs', '3',\n",
@@ -225,31 +198,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "10:39:54 INFO:Reserving TFSparkNodes \n",
-      "10:39:54 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
-      "10:39:54 INFO:listening for reservations at ('9.0.7.2', 35579)\n",
-      "10:39:54 INFO:Starting TensorFlow on executors\n",
-      "10:39:55 INFO:Waiting for TFSparkNodes to start\n",
-      "10:39:55 INFO:waiting for 5 reservations\n",
-      "10:39:56 INFO:waiting for 5 reservations\n",
-      "10:39:57 INFO:waiting for 5 reservations\n",
-      "10:39:58 INFO:waiting for 5 reservations\n",
-      "10:39:59 INFO:waiting for 4 reservations\n",
-      "10:40:00 INFO:all reservations completed\n",
-      "10:40:00 INFO:All TFSparkNodes started\n",
-      "10:40:00 INFO:{'executor_id': 2, 'host': '10.0.4.228', 'job_name': 'worker', 'task_index': 2, 'port': 35825, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-c01_wacm/listener-99upz2mo', 'authkey': b'\\xbc\\xce`n\\xdboH\\x91\\xbd/<\\xfa[\\xfb\\x15r'}\n",
-      "10:40:00 INFO:{'executor_id': 4, 'host': '10.0.7.225', 'job_name': 'worker', 'task_index': 4, 'port': 46340, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-afgx4tuj/listener-_al9izeg', 'authkey': b'\\xe7W\\xc8\\xb1\\x82IAP\\x96G\\x9c\\x7fI\\x0b2\\x1c'}\n",
-      "10:40:00 INFO:{'executor_id': 3, 'host': '10.0.4.91', 'job_name': 'worker', 'task_index': 3, 'port': 45528, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-vc5ws3zu/listener-cbt3mo9e', 'authkey': b'uv@$\\xf0\\x94O\\xab\\xb0\\x0c\\x87\\x85K\\xbf\\x90\\x88'}\n",
-      "10:40:00 INFO:{'executor_id': 1, 'host': '10.0.4.116', 'job_name': 'worker', 'task_index': 1, 'port': 39532, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1rwhkoxv/listener-a3_5tb26', 'authkey': b'(tAO\\x19kJ\\x86\\xb6\\x17\\xb1\\x07\\x01\\xfe\\xc4l'}\n",
-      "10:40:00 INFO:{'executor_id': 0, 'host': '10.0.5.225', 'job_name': 'worker', 'task_index': 0, 'port': 39948, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-5rvwiq59/listener-j8dmpe6x', 'authkey': b'\\xfd\\x83\\xe0\\xb7\\xd9\\xceB\\xd0\\xacx\\xd0\\r \\xed\\x840'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Start the cluster for training\n",
     "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, args.num_ps, False, TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)"
@@ -261,16 +210,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "10:41:24 INFO:Stopping TensorFlow nodes\n",
-      "10:41:24 INFO:Shutting down cluster\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cluster.shutdown()"
    ]
@@ -281,15 +221,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "b'Found 10 items\\n-rw-r--r--   3 nobody supergroup        128 2018-11-05 22:40 mnist_model/checkpoint\\n-rw-r--r--   3 nobody supergroup         40 2018-11-05 22:40 mnist_model/events.out.tfevents.1541457603.ip-10-0-5-225.us-west-2.compute.internal\\n-rw-r--r--   3 nobody supergroup     179586 2018-11-05 22:40 mnist_model/graph.pbtxt\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-05 22:40 mnist_model/model.ckpt-0.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-05 22:40 mnist_model/model.ckpt-0.index\\n-rw-r--r--   3 nobody supergroup      66439 2018-11-05 22:40 mnist_model/model.ckpt-0.meta\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-05 22:40 mnist_model/model.ckpt-354.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-05 22:40 mnist_model/model.ckpt-354.index\\n-rw-r--r--   3 nobody supergroup      66439 2018-11-05 22:40 mnist_model/model.ckpt-354.meta\\ndrwxr-xr-x   - nobody supergroup          0 2018-11-05 22:40 mnist_model/train\\n'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# See if mnist_model was successfully created\n",
     "print(subprocess.check_output(shlex.split('hdfs dfs -ls mnist_model')))"
@@ -301,15 +233,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=3, format='tfr', images_labels='mnist/tfr/train', mode='inference', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Parse arguments for inference\n",
     "args = parser.parse_args(['--mode', 'inference', '--epochs', '3',\n",
@@ -328,28 +252,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "10:41:48 INFO:Reserving TFSparkNodes \n",
-      "10:41:48 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
-      "10:41:48 INFO:listening for reservations at ('9.0.7.2', 35357)\n",
-      "10:41:48 INFO:Starting TensorFlow on executors\n",
-      "10:41:48 INFO:Waiting for TFSparkNodes to start\n",
-      "10:41:48 INFO:waiting for 5 reservations\n",
-      "10:41:49 INFO:waiting for 5 reservations\n",
-      "10:41:50 INFO:all reservations completed\n",
-      "10:41:50 INFO:All TFSparkNodes started\n",
-      "10:41:50 INFO:{'executor_id': 0, 'host': '10.0.4.228', 'job_name': 'worker', 'task_index': 0, 'port': 40124, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-0gzba7qn/listener-52gcid_c', 'authkey': b'-Tic\\xeb\\xefH\\xa2\\x97\\x9c\\x1bTs\\xbd5\\xe8'}\n",
-      "10:41:50 INFO:{'executor_id': 4, 'host': '10.0.7.225', 'job_name': 'worker', 'task_index': 4, 'port': 39938, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-_45qn21g/listener-soc8dl60', 'authkey': b'\\x08\\xe2)\\xc6\\x13:Gp\\x9b1\\xd2\\x8c|\\x17\\xf1m'}\n",
-      "10:41:50 INFO:{'executor_id': 2, 'host': '10.0.4.116', 'job_name': 'worker', 'task_index': 2, 'port': 38315, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-w599fmp7/listener-ng1nrq8q', 'authkey': b'+j\\xc0D\\xa3\\x94D\\x19\\x88\\xe7wZ\\xb6\\xfdJ:'}\n",
-      "10:41:50 INFO:{'executor_id': 1, 'host': '10.0.4.91', 'job_name': 'worker', 'task_index': 1, 'port': 37554, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-rz35vv19/listener-7ogl_txj', 'authkey': b's\\x8a\\xe4\\r\\xad\\x07Eo\\xa1{\\xe3\\xcfl\\xfaId'}\n",
-      "10:41:50 INFO:{'executor_id': 3, 'host': '10.0.5.225', 'job_name': 'worker', 'task_index': 3, 'port': 38123, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1ox2i9k7/listener-3lmqwmv0', 'authkey': b'N\\x91*\\t\\x02\\xf6E\\\\\\xb8\\x07\\x9b\\xae\\xfaH.\\xeb'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Start the cluster for inference\n",
     "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, args.num_ps, False, TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)"
@@ -372,18 +275,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['0 0', '6 6', '4 4', '4 4', '4 4', '9 9', '2 2', '3 3', '8 8', '8 8']"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "predictions.take(10)"
    ]
@@ -394,16 +286,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "10:44:04 INFO:Stopping TensorFlow nodes\n",
-      "10:44:04 INFO:Shutting down cluster\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cluster.shutdown()"
    ]

--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
@@ -25,20 +25,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "b''"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Remove existing models/artifacts if any\n",
     "subprocess.check_output('hdfs dfs -rm -R -f -skipTrash mnist', shell=True)\n",
@@ -50,70 +39,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "b''"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Clone the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark\n",
-    "subprocess.check_output('git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark', shell=True)"
+    "subprocess.check_output('cd $MESOS_SANDBOX && git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark', shell=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "b'Archive:  mnist.zip\\n   creating: mnist/\\n  inflating: mnist/train-images-idx3-ubyte.gz  \\n extracting: mnist/train-labels-idx1-ubyte.gz  \\n  inflating: mnist/t10k-images-idx3-ubyte.gz  \\n extracting: mnist/t10k-labels-idx1-ubyte.gz  \\n'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Download the mnist example \n",
-    "subprocess.check_output('curl -fsSL -O https://downloads.mesosphere.com/data-science/assets/mnist.zip && unzip mnist.zip', shell=True)"
+    "subprocess.check_output('cd $MESOS_SANDBOX && curl -fsSL -O https://downloads.mesosphere.com/data-science/assets/mnist.zip && unzip mnist.zip', shell=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "b\"args: Namespace(format='csv2', num_partitions=10, output='mnist/csv2', read=False, verify=False)\\n2018-11-04 05:05:31,984 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Running Spark version 2.2.1\\n2018-11-04 05:05:32,012 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Submitted application: mnist_parallelize\\n2018-11-04 05:05:32,030 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing view acls to: nobody\\n2018-11-04 05:05:32,031 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing modify acls to: nobody\\n2018-11-04 05:05:32,031 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing view acls groups to: \\n2018-11-04 05:05:32,032 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - Changing modify acls groups to: \\n2018-11-04 05:05:32,032 INFO  [Thread-4] spark.SecurityManager (Logging.scala:logInfo(54)) - SecurityManager: authentication disabled; ui acls disabled; users  with view permissions: Set(nobody); groups with view permissions: Set(); users  with modify permissions: Set(nobody); groups with modify permissions: Set()\\n2018-11-04 05:05:32,266 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Successfully started service 'sparkDriver' on port 7077.\\n2018-11-04 05:05:32,283 INFO  [Thread-4] spark.SparkEnv (Logging.scala:logInfo(54)) - Registering MapOutputTracker\\n2018-11-04 05:05:32,300 INFO  [Thread-4] spark.SparkEnv (Logging.scala:logInfo(54)) - Registering BlockManagerMaster\\n2018-11-04 05:05:32,303 INFO  [Thread-4] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information\\n2018-11-04 05:05:32,303 INFO  [Thread-4] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - BlockManagerMasterEndpoint up\\n2018-11-04 05:05:32,311 INFO  [Thread-4] storage.DiskBlockManager (Logging.scala:logInfo(54)) - Created local directory at /mnt/mesos/sandbox/blockmgr-7a9fcb81-b361-4586-bc6b-070b1831d7fe\\n2018-11-04 05:05:32,332 INFO  [Thread-4] memory.MemoryStore (Logging.scala:logInfo(54)) - MemoryStore started with capacity 3.4 GB\\n2018-11-04 05:05:32,361 INFO  [Thread-4] metrics.MetricsConfig (Logging.scala:logInfo(54)) - Loading metrics properties from resource metrics.properties\\n2018-11-04 05:05:32,362 INFO  [Thread-4] metrics.MetricsConfig (Logging.scala:logInfo(54)) - Metrics properties: {*.sink.servlet.path=/metrics/json, applications.sink.servlet.path=/metrics/applications/json, *.sink.servlet.class=org.apache.spark.metrics.sink.MetricsServlet, master.sink.servlet.path=/metrics/master/json}\\n2018-11-04 05:05:32,369 INFO  [Thread-4] spark.SparkEnv (Logging.scala:logInfo(54)) - Registering OutputCommitCoordinator\\n2018-11-04 05:05:32,441 INFO  [Thread-4] util.log (Log.java:initialized(192)) - Logging initialized @10390ms\\n2018-11-04 05:05:32,495 INFO  [Thread-4] server.Server (Server.java:doStart(345)) - jetty-9.3.z-SNAPSHOT\\n2018-11-04 05:05:32,508 INFO  [Thread-4] server.Server (Server.java:doStart(403)) - Started @10458ms\\n2018-11-04 05:05:32,526 INFO  [Thread-4] server.AbstractConnector (AbstractConnector.java:doStart(270)) - Started ServerConnector@4c2af2bb{HTTP/1.1,[http/1.1]}{0.0.0.0:4040}\\n2018-11-04 05:05:32,526 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Successfully started service 'SparkUI' on port 4040.\\n2018-11-04 05:05:32,547 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5b64a772{/jobs,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,547 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@c326c13{/jobs/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,548 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@4172357d{/jobs/job,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,549 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3f836c5d{/jobs/job/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,549 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@6366bbf7{/stages,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,550 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3982090d{/stages/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,550 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5323d16a{/stages/stage,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,551 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@774caee7{/stages/stage/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,552 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@43358919{/stages/pool,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,552 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@274149b2{/stages/pool/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,553 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@63277d25{/storage,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,553 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3c0f4f73{/storage/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,554 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@420d6ab2{/storage/rdd,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,555 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@61b55a6a{/storage/rdd/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,555 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@d0e9570{/environment,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,556 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5ed599ad{/environment/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,556 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@7a365b53{/executors,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,557 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5a4d8c48{/executors/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,557 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@460d2aac{/executors/threadDump,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,558 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@63200c3e{/executors/threadDump/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,564 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@a9fd4a4{/static,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,564 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@5b09255c{/,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,565 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@51e1b160{/api,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,566 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@56191c60{/jobs/job/kill,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,567 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@3c0cb310{/stages/stage/kill,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:32,568 INFO  [Thread-4] ui.SparkUI (Logging.scala:logInfo(54)) - Bound SparkUI to 9.0.12.2, and started at http://9.0.12.2:4040\\n2018-11-04 05:05:32,585 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar with timestamp 1541307932585\\n2018-11-04 05:05:32,585 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar with timestamp 1541307932585\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.spark-project.spark_unused-1.0.0.jar at spark://9.0.12.2:7077/jars/org.spark-project.spark_unused-1.0.0.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar at spark://9.0.12.2:7077/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar at spark://9.0.12.2:7077/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/com.yammer.metrics_metrics-core-2.2.0.jar at spark://9.0.12.2:7077/jars/com.yammer.metrics_metrics-core-2.2.0.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-log4j12-1.7.21.jar at spark://9.0.12.2:7077/jars/org.slf4j_slf4j-log4j12-1.7.21.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,586 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/com.101tec_zkclient-0.10.jar at spark://9.0.12.2:7077/jars/com.101tec_zkclient-0.10.jar with timestamp 1541307932586\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.zookeeper_zookeeper-3.4.9.jar at spark://9.0.12.2:7077/jars/org.apache.zookeeper_zookeeper-3.4.9.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar at spark://9.0.12.2:7077/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/net.jpountz.lz4_lz4-1.3.0.jar at spark://9.0.12.2:7077/jars/net.jpountz.lz4_lz4-1.3.0.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar at spark://9.0.12.2:7077/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-api-1.7.21.jar at spark://9.0.12.2:7077/jars/org.slf4j_slf4j-api-1.7.21.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,587 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added JAR file:/mnt/mesos/sandbox/.ivy2/jars/log4j_log4j-1.2.17.jar at spark://9.0.12.2:7077/jars/log4j_log4j-1.2.17.jar with timestamp 1541307932587\\n2018-11-04 05:05:32,849 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py at spark://9.0.12.2:7077/files/mnist_data_setup.py with timestamp 1541307932848\\n2018-11-04 05:05:32,850 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/mnist_data_setup.py\\n2018-11-04 05:05:32,857 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar at spark://9.0.12.2:7077/files/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar with timestamp 1541307932857\\n2018-11-04 05:05:32,858 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.spark_spark-streaming-kafka-0-10_2.11-2.2.1.jar\\n2018-11-04 05:05:32,861 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar at spark://9.0.12.2:7077/files/org.apache.kafka_kafka_2.11-0.10.2.1.jar with timestamp 1541307932861\\n2018-11-04 05:05:32,861 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka_2.11-0.10.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.kafka_kafka_2.11-0.10.2.1.jar\\n2018-11-04 05:05:32,869 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar at spark://9.0.12.2:7077/files/org.apache.spark_spark-tags_2.11-2.2.1.jar with timestamp 1541307932869\\n2018-11-04 05:05:32,869 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.spark_spark-tags_2.11-2.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.spark_spark-tags_2.11-2.2.1.jar\\n2018-11-04 05:05:32,872 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.spark-project.spark_unused-1.0.0.jar at spark://9.0.12.2:7077/files/org.spark-project.spark_unused-1.0.0.jar with timestamp 1541307932872\\n2018-11-04 05:05:32,872 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.spark-project.spark_unused-1.0.0.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.spark-project.spark_unused-1.0.0.jar\\n2018-11-04 05:05:32,881 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar at spark://9.0.12.2:7077/files/org.apache.kafka_kafka-clients-0.10.2.1.jar with timestamp 1541307932881\\n2018-11-04 05:05:32,881 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.kafka_kafka-clients-0.10.2.1.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.kafka_kafka-clients-0.10.2.1.jar\\n2018-11-04 05:05:32,885 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar at spark://9.0.12.2:7077/files/net.sf.jopt-simple_jopt-simple-5.0.3.jar with timestamp 1541307932885\\n2018-11-04 05:05:32,886 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/net.sf.jopt-simple_jopt-simple-5.0.3.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/net.sf.jopt-simple_jopt-simple-5.0.3.jar\\n2018-11-04 05:05:32,889 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/com.yammer.metrics_metrics-core-2.2.0.jar at spark://9.0.12.2:7077/files/com.yammer.metrics_metrics-core-2.2.0.jar with timestamp 1541307932889\\n2018-11-04 05:05:32,889 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/com.yammer.metrics_metrics-core-2.2.0.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/com.yammer.metrics_metrics-core-2.2.0.jar\\n2018-11-04 05:05:32,892 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-log4j12-1.7.21.jar at spark://9.0.12.2:7077/files/org.slf4j_slf4j-log4j12-1.7.21.jar with timestamp 1541307932892\\n2018-11-04 05:05:32,892 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-log4j12-1.7.21.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.slf4j_slf4j-log4j12-1.7.21.jar\\n2018-11-04 05:05:32,895 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/com.101tec_zkclient-0.10.jar at spark://9.0.12.2:7077/files/com.101tec_zkclient-0.10.jar with timestamp 1541307932895\\n2018-11-04 05:05:32,896 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/com.101tec_zkclient-0.10.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/com.101tec_zkclient-0.10.jar\\n2018-11-04 05:05:32,899 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.apache.zookeeper_zookeeper-3.4.9.jar at spark://9.0.12.2:7077/files/org.apache.zookeeper_zookeeper-3.4.9.jar with timestamp 1541307932899\\n2018-11-04 05:05:32,899 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.apache.zookeeper_zookeeper-3.4.9.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.apache.zookeeper_zookeeper-3.4.9.jar\\n2018-11-04 05:05:32,903 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar at spark://9.0.12.2:7077/files/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar with timestamp 1541307932903\\n2018-11-04 05:05:32,903 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.scala-lang.modules_scala-parser-combinators_2.11-1.0.4.jar\\n2018-11-04 05:05:32,906 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/net.jpountz.lz4_lz4-1.3.0.jar at spark://9.0.12.2:7077/files/net.jpountz.lz4_lz4-1.3.0.jar with timestamp 1541307932906\\n2018-11-04 05:05:32,907 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/net.jpountz.lz4_lz4-1.3.0.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/net.jpountz.lz4_lz4-1.3.0.jar\\n2018-11-04 05:05:32,910 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar at spark://9.0.12.2:7077/files/org.xerial.snappy_snappy-java-1.1.2.6.jar with timestamp 1541307932910\\n2018-11-04 05:05:32,910 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.xerial.snappy_snappy-java-1.1.2.6.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.xerial.snappy_snappy-java-1.1.2.6.jar\\n2018-11-04 05:05:32,914 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-api-1.7.21.jar at spark://9.0.12.2:7077/files/org.slf4j_slf4j-api-1.7.21.jar with timestamp 1541307932914\\n2018-11-04 05:05:32,914 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/org.slf4j_slf4j-api-1.7.21.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/org.slf4j_slf4j-api-1.7.21.jar\\n2018-11-04 05:05:32,917 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Added file file:/mnt/mesos/sandbox/.ivy2/jars/log4j_log4j-1.2.17.jar at spark://9.0.12.2:7077/files/log4j_log4j-1.2.17.jar with timestamp 1541307932917\\n2018-11-04 05:05:32,917 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Copying /mnt/mesos/sandbox/.ivy2/jars/log4j_log4j-1.2.17.jar to /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/userFiles-01e0bfae-a5d9-4472-9303-55998254b5d7/log4j_log4j-1.2.17.jar\\n2018-11-04 05:05:33,026 WARN  [Thread-4] metrics.MetricsSystem (Logging.scala:logWarning(66)) - Using default name mesos_cluster for source because neither spark.metrics.namespace nor spark.app.id is set.\\n2018-11-04 05:05:33,027 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: mesos_cluster\\n2018-11-04 05:05:33,168 INFO  [Thread-4] util.Utils (Logging.scala:logInfo(54)) - Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 43132.\\n2018-11-04 05:05:33,169 INFO  [Thread-4] netty.NettyBlockTransferService (Logging.scala:logInfo(54)) - Server created on 9.0.12.2:43132\\n2018-11-04 05:05:33,170 INFO  [Thread-4] storage.BlockManager (Logging.scala:logInfo(54)) - Using org.apache.spark.storage.RandomBlockReplicationPolicy for block replication policy\\n2018-11-04 05:05:33,172 INFO  [Thread-4] storage.BlockManagerMaster (Logging.scala:logInfo(54)) - Registering BlockManager BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,176 INFO  [dispatcher-event-loop-1] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 9.0.12.2:43132 with 3.4 GB RAM, BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,181 INFO  [Thread-4] storage.BlockManagerMaster (Logging.scala:logInfo(54)) - Registered BlockManager BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,182 INFO  [Thread-4] storage.BlockManager (Logging.scala:logInfo(54)) - Initialized BlockManager: BlockManagerId(driver, 9.0.12.2, 43132, None)\\n2018-11-04 05:05:33,184 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.CodeGenerator\\n2018-11-04 05:05:33,184 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.HiveExternalCatalog\\n2018-11-04 05:05:33,186 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Initializing sink: org.apache.spark.metrics.sink.MetricsServlet\\n2018-11-04 05:05:33,344 INFO  [Thread-4] handler.ContextHandler (ContextHandler.java:doStart(781)) - Started o.s.j.s.ServletContextHandler@159ad6ad{/metrics/json,null,AVAILABLE,@Spark}\\n2018-11-04 05:05:35,103 INFO  [Thread-35] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 0 is now TASK_STARTING\\n2018-11-04 05:05:35,107 INFO  [Thread-36] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 0 is now TASK_RUNNING\\n2018-11-04 05:05:35,181 INFO  [Thread-37] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 1 is now TASK_STARTING\\n2018-11-04 05:05:35,184 INFO  [Thread-38] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 1 is now TASK_RUNNING\\n2018-11-04 05:05:35,298 INFO  [Thread-39] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 3 is now TASK_STARTING\\n2018-11-04 05:05:35,301 INFO  [Thread-40] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 3 is now TASK_RUNNING\\n2018-11-04 05:05:35,375 INFO  [Thread-41] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 2 is now TASK_STARTING\\n2018-11-04 05:05:35,379 INFO  [Thread-42] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 2 is now TASK_RUNNING\\n2018-11-04 05:05:35,388 INFO  [Thread-43] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 4 is now TASK_STARTING\\n2018-11-04 05:05:35,391 INFO  [Thread-44] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 4 is now TASK_RUNNING\\n2018-11-04 05:05:38,780 INFO  [dispatcher-event-loop-0] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.12:49318) with ID 1\\n2018-11-04 05:05:38,820 INFO  [dispatcher-event-loop-1] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.5.21:41167 with 3.4 GB RAM, BlockManagerId(1, 10.0.5.21, 41167, None)\\n2018-11-04 05:05:38,869 INFO  [dispatcher-event-loop-2] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.10:49670) with ID 0\\n2018-11-04 05:05:38,877 INFO  [dispatcher-event-loop-1] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.16:59356) with ID 3\\n2018-11-04 05:05:38,906 INFO  [dispatcher-event-loop-2] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.6.159:33911 with 3.4 GB RAM, BlockManagerId(0, 10.0.6.159, 33911, None)\\n2018-11-04 05:05:38,914 INFO  [dispatcher-event-loop-2] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.6.242:35839 with 3.4 GB RAM, BlockManagerId(3, 10.0.6.242, 35839, None)\\n2018-11-04 05:05:38,944 INFO  [dispatcher-event-loop-0] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.7:58360) with ID 2\\n2018-11-04 05:05:38,980 INFO  [dispatcher-event-loop-1] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.4.250:37259 with 3.4 GB RAM, BlockManagerId(2, 10.0.4.250, 37259, None)\\n2018-11-04 05:05:39,013 INFO  [dispatcher-event-loop-2] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Registered executor NettyRpcEndpointRef(spark-client://Executor) (44.128.0.9:36692) with ID 4\\n2018-11-04 05:05:39,081 INFO  [dispatcher-event-loop-0] storage.BlockManagerMasterEndpoint (Logging.scala:logInfo(54)) - Registering block manager 10.0.5.82:39721 with 3.4 GB RAM, BlockManagerId(4, 10.0.5.82, 39721, None)\\n2018-11-04 05:05:39,103 INFO  [Thread-4] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - SchedulerBackend is ready for scheduling beginning after reached minRegisteredResourcesRatio: 1.0\\n2018-11-04 05:05:39,104 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.DAGScheduler\\n2018-11-04 05:05:39,108 INFO  [Thread-4] metrics.MetricsSystem (Logging.scala:logInfo(54)) - Registering source: 89f0bb48-25ea-473e-9c1b-7a210c2b8f2f-0079.driver.BlockManager\\nWARNING:tensorflow:From /mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py:48: extract_images (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.\\nInstructions for updating:\\nPlease use tf.data to implement this functionality.\\nExtracting mnist/train-images-idx3-ubyte.gz\\nWARNING:tensorflow:From /mnt/mesos/sandbox/dcos-jupyter-service/notebooks/tensorflowonspark/examples/mnist/mnist_data_setup.py:52: extract_labels (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.\\nInstructions for updating:\\nPlease use tf.data to implement this functionality.\\nExtracting mnist/train-labels-idx1-ubyte.gz\\nimages.shape: (60000, 28, 28, 1)\\nlabels.shape: (60000,)\\n2018-11-04 05:05:40,799 INFO  [Thread-4] deploy.SparkHadoopUtil (Logging.scala:logInfo(54)) - Adding user credentials: List()\\n2018-11-04 05:05:40,871 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(123)) - File Output Committer Algorithm version is 1\\n2018-11-04 05:05:40,871 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(138)) - FileOutputCommitter skip cleanup _temporary folders under output directory:false, ignore cleanup failures: false\\n2018-11-04 05:05:40,974 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Starting job: saveAsTextFile at NativeMethodAccessorImpl.java:0\\n2018-11-04 05:05:40,984 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Got job 0 (saveAsTextFile at NativeMethodAccessorImpl.java:0) with 10 output partitions\\n2018-11-04 05:05:40,984 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Final stage: ResultStage 0 (saveAsTextFile at NativeMethodAccessorImpl.java:0)\\n2018-11-04 05:05:40,985 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Parents of final stage: List()\\n2018-11-04 05:05:40,986 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Missing parents: List()\\n2018-11-04 05:05:40,995 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting ResultStage 0 (MapPartitionsRDD[7] at saveAsTextFile at NativeMethodAccessorImpl.java:0), which has no missing parents\\n2018-11-04 05:05:41,117 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_0 stored as values in memory (estimated size 176.1 KB, free 3.4 GB)\\n2018-11-04 05:05:41,150 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_0_piece0 stored as bytes in memory (estimated size 55.3 KB, free 3.4 GB)\\n2018-11-04 05:05:41,152 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 9.0.12.2:43132 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:41,154 INFO  [dag-scheduler-event-loop] spark.SparkContext (Logging.scala:logInfo(54)) - Created broadcast 0 from broadcast at DAGScheduler.scala:1006\\n2018-11-04 05:05:41,164 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting 10 missing tasks from ResultStage 0 (MapPartitionsRDD[7] at saveAsTextFile at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))\\n2018-11-04 05:05:41,173 INFO  [dag-scheduler-event-loop] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Adding task set 0.0 with 10 tasks\\n2018-11-04 05:05:41,205 WARN  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logWarning(66)) - Stage 0 contains a task of very large size (4299 KB). The maximum recommended task size is 100 KB.\\n2018-11-04 05:05:41,206 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 0.0 in stage 0.0 (TID 0, 10.0.6.159, executor 0, partition 0, PROCESS_LOCAL, 4402486 bytes)\\n2018-11-04 05:05:41,213 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 1.0 in stage 0.0 (TID 1, 10.0.4.250, executor 2, partition 1, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:41,229 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 2.0 in stage 0.0 (TID 2, 10.0.5.21, executor 1, partition 2, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:41,234 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 3.0 in stage 0.0 (TID 3, 10.0.5.82, executor 4, partition 3, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:41,241 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 4.0 in stage 0.0 (TID 4, 10.0.6.242, executor 3, partition 4, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:42,609 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.6.242:35839 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,656 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.4.250:37259 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,879 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.6.159:33911 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,890 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.5.21:41167 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:42,891 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_0_piece0 in memory on 10.0.5.82:39721 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:48,873 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 5.0 in stage 0.0 (TID 5, 10.0.6.159, executor 0, partition 5, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:48,876 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 0.0 in stage 0.0 (TID 0) in 7686 ms on 10.0.6.159 (executor 0) (1/10)\\n2018-11-04 05:05:49,385 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 6.0 in stage 0.0 (TID 6, 10.0.5.82, executor 4, partition 6, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:49,386 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 3.0 in stage 0.0 (TID 3) in 8157 ms on 10.0.5.82 (executor 4) (2/10)\\n2018-11-04 05:05:49,469 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 7.0 in stage 0.0 (TID 7, 10.0.5.21, executor 1, partition 7, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:49,470 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 2.0 in stage 0.0 (TID 2) in 8256 ms on 10.0.5.21 (executor 1) (3/10)\\n2018-11-04 05:05:49,565 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 8.0 in stage 0.0 (TID 8, 10.0.4.250, executor 2, partition 8, PROCESS_LOCAL, 5281952 bytes)\\n2018-11-04 05:05:49,566 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 1.0 in stage 0.0 (TID 1) in 8359 ms on 10.0.4.250 (executor 2) (4/10)\\n2018-11-04 05:05:49,859 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 9.0 in stage 0.0 (TID 9, 10.0.6.242, executor 3, partition 9, PROCESS_LOCAL, 4924188 bytes)\\n2018-11-04 05:05:49,859 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 4.0 in stage 0.0 (TID 4) in 8625 ms on 10.0.6.242 (executor 3) (5/10)\\n2018-11-04 05:05:53,239 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 5.0 in stage 0.0 (TID 5) in 4373 ms on 10.0.6.159 (executor 0) (6/10)\\n2018-11-04 05:05:53,837 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 9.0 in stage 0.0 (TID 9) in 3983 ms on 10.0.6.242 (executor 3) (7/10)\\n2018-11-04 05:05:53,848 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 7.0 in stage 0.0 (TID 7) in 4384 ms on 10.0.5.21 (executor 1) (8/10)\\n2018-11-04 05:05:53,859 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 6.0 in stage 0.0 (TID 6) in 4484 ms on 10.0.5.82 (executor 4) (9/10)\\n2018-11-04 05:05:54,046 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 8.0 in stage 0.0 (TID 8) in 4485 ms on 10.0.4.250 (executor 2) (10/10)\\n2018-11-04 05:05:54,047 INFO  [task-result-getter-1] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Removed TaskSet 0.0, whose tasks have all completed, from pool \\n2018-11-04 05:05:54,048 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - ResultStage 0 (saveAsTextFile at NativeMethodAccessorImpl.java:0) finished in 12.861 s\\n2018-11-04 05:05:54,053 INFO  [Thread-4] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Job 0 finished: saveAsTextFile at NativeMethodAccessorImpl.java:0, took 13.077980 s\\n2018-11-04 05:05:54,262 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 9.0.12.2:43132 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,266 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.6.242:35839 in memory (size: 55.3 KB, free: 3.4 GB)\\nExtracting mnist/t10k-images-idx3-ubyte.gz\\n2018-11-04 05:05:54,333 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.4.250:37259 in memory (size: 55.3 KB, free: 3.4 GB)\\nExtracting mnist/t10k-labels-idx1-ubyte.gz\\nimages.shape: (10000, 28, 28, 1)\\nlabels.shape: (10000,)\\n2018-11-04 05:05:54,343 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.5.21:41167 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,347 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.6.159:33911 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,347 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Removed broadcast_0_piece0 on 10.0.5.82:39721 in memory (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,493 INFO  [Thread-4] deploy.SparkHadoopUtil (Logging.scala:logInfo(54)) - Adding user credentials: List()\\n2018-11-04 05:05:54,495 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(123)) - File Output Committer Algorithm version is 1\\n2018-11-04 05:05:54,495 INFO  [Thread-4] output.FileOutputCommitter (FileOutputCommitter.java:<init>(138)) - FileOutputCommitter skip cleanup _temporary folders under output directory:false, ignore cleanup failures: false\\n2018-11-04 05:05:54,513 INFO  [Thread-4] spark.SparkContext (Logging.scala:logInfo(54)) - Starting job: saveAsTextFile at NativeMethodAccessorImpl.java:0\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Got job 1 (saveAsTextFile at NativeMethodAccessorImpl.java:0) with 10 output partitions\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Final stage: ResultStage 1 (saveAsTextFile at NativeMethodAccessorImpl.java:0)\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Parents of final stage: List()\\n2018-11-04 05:05:54,514 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Missing parents: List()\\n2018-11-04 05:05:54,515 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting ResultStage 1 (MapPartitionsRDD[15] at saveAsTextFile at NativeMethodAccessorImpl.java:0), which has no missing parents\\n2018-11-04 05:05:54,529 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_1 stored as values in memory (estimated size 176.1 KB, free 3.4 GB)\\n2018-11-04 05:05:54,532 INFO  [dag-scheduler-event-loop] memory.MemoryStore (Logging.scala:logInfo(54)) - Block broadcast_1_piece0 stored as bytes in memory (estimated size 55.3 KB, free 3.4 GB)\\n2018-11-04 05:05:54,532 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 9.0.12.2:43132 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,533 INFO  [dag-scheduler-event-loop] spark.SparkContext (Logging.scala:logInfo(54)) - Created broadcast 1 from broadcast at DAGScheduler.scala:1006\\n2018-11-04 05:05:54,534 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Submitting 10 missing tasks from ResultStage 1 (MapPartitionsRDD[15] at saveAsTextFile at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))\\n2018-11-04 05:05:54,534 INFO  [dag-scheduler-event-loop] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Adding task set 1.0 with 10 tasks\\n2018-11-04 05:05:54,535 WARN  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logWarning(66)) - Stage 1 contains a task of very large size (843 KB). The maximum recommended task size is 100 KB.\\n2018-11-04 05:05:54,535 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 0.0 in stage 1.0 (TID 10, 10.0.5.21, executor 1, partition 0, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,536 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 1.0 in stage 1.0 (TID 11, 10.0.5.82, executor 4, partition 1, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,537 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 2.0 in stage 1.0 (TID 12, 10.0.6.159, executor 0, partition 2, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,538 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 3.0 in stage 1.0 (TID 13, 10.0.6.242, executor 3, partition 3, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,539 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 4.0 in stage 1.0 (TID 14, 10.0.4.250, executor 2, partition 4, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:54,579 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.5.82:39721 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,582 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.6.242:35839 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,600 INFO  [dispatcher-event-loop-0] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.4.250:37259 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,643 INFO  [dispatcher-event-loop-1] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.5.21:41167 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:54,676 INFO  [dispatcher-event-loop-2] storage.BlockManagerInfo (Logging.scala:logInfo(54)) - Added broadcast_1_piece0 in memory on 10.0.6.159:33911 (size: 55.3 KB, free: 3.4 GB)\\n2018-11-04 05:05:55,350 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 5.0 in stage 1.0 (TID 15, 10.0.4.250, executor 2, partition 5, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,351 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 4.0 in stage 1.0 (TID 14) in 813 ms on 10.0.4.250 (executor 2) (1/10)\\n2018-11-04 05:05:55,353 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 6.0 in stage 1.0 (TID 16, 10.0.5.82, executor 4, partition 6, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,354 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 1.0 in stage 1.0 (TID 11) in 818 ms on 10.0.5.82 (executor 4) (2/10)\\n2018-11-04 05:05:55,566 INFO  [dispatcher-event-loop-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 7.0 in stage 1.0 (TID 17, 10.0.6.159, executor 0, partition 7, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,566 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 2.0 in stage 1.0 (TID 12) in 1030 ms on 10.0.6.159 (executor 0) (3/10)\\n2018-11-04 05:05:55,850 INFO  [dispatcher-event-loop-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 8.0 in stage 1.0 (TID 18, 10.0.5.21, executor 1, partition 8, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,850 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 0.0 in stage 1.0 (TID 10) in 1315 ms on 10.0.5.21 (executor 1) (4/10)\\n2018-11-04 05:05:55,870 INFO  [dispatcher-event-loop-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Starting task 9.0 in stage 1.0 (TID 19, 10.0.6.242, executor 3, partition 9, PROCESS_LOCAL, 863978 bytes)\\n2018-11-04 05:05:55,870 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 3.0 in stage 1.0 (TID 13) in 1333 ms on 10.0.6.242 (executor 3) (5/10)\\n2018-11-04 05:05:56,243 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 6.0 in stage 1.0 (TID 16) in 891 ms on 10.0.5.82 (executor 4) (6/10)\\n2018-11-04 05:05:56,243 INFO  [task-result-getter-0] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 5.0 in stage 1.0 (TID 15) in 894 ms on 10.0.4.250 (executor 2) (7/10)\\n2018-11-04 05:05:56,371 INFO  [task-result-getter-1] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 7.0 in stage 1.0 (TID 17) in 806 ms on 10.0.6.159 (executor 0) (8/10)\\n2018-11-04 05:05:56,760 INFO  [task-result-getter-2] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 8.0 in stage 1.0 (TID 18) in 911 ms on 10.0.5.21 (executor 1) (9/10)\\n2018-11-04 05:05:56,762 INFO  [task-result-getter-3] scheduler.TaskSetManager (Logging.scala:logInfo(54)) - Finished task 9.0 in stage 1.0 (TID 19) in 893 ms on 10.0.6.242 (executor 3) (10/10)\\n2018-11-04 05:05:56,762 INFO  [task-result-getter-3] scheduler.TaskSchedulerImpl (Logging.scala:logInfo(54)) - Removed TaskSet 1.0, whose tasks have all completed, from pool \\n2018-11-04 05:05:56,763 INFO  [dag-scheduler-event-loop] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - ResultStage 1 (saveAsTextFile at NativeMethodAccessorImpl.java:0) finished in 2.229 s\\n2018-11-04 05:05:56,763 INFO  [Thread-4] scheduler.DAGScheduler (Logging.scala:logInfo(54)) - Job 1 finished: saveAsTextFile at NativeMethodAccessorImpl.java:0, took 2.250033 s\\n2018-11-04 05:05:57,278 INFO  [pool-7-thread-1] spark.SparkContext (Logging.scala:logInfo(54)) - Invoking stop() from shutdown hook\\n2018-11-04 05:05:57,283 INFO  [pool-7-thread-1] server.AbstractConnector (AbstractConnector.java:doStop(310)) - Stopped Spark@4c2af2bb{HTTP/1.1,[http/1.1]}{9.0.12.2:4040}\\n2018-11-04 05:05:57,284 INFO  [pool-7-thread-1] ui.SparkUI (Logging.scala:logInfo(54)) - Stopped Spark web UI at http://9.0.12.2:4040\\n2018-11-04 05:05:57,289 INFO  [pool-7-thread-1] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Shutting down all executors\\n2018-11-04 05:05:57,289 INFO  [dispatcher-event-loop-2] cluster.CoarseGrainedSchedulerBackend$DriverEndpoint (Logging.scala:logInfo(54)) - Asking each executor to shut down\\n2018-11-04 05:05:57,861 INFO  [Thread-52] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 0 is now TASK_FINISHED\\n2018-11-04 05:05:57,946 INFO  [Thread-54] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 2 is now TASK_FINISHED\\n2018-11-04 05:05:57,956 INFO  [Thread-56] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 1 is now TASK_FINISHED\\n2018-11-04 05:05:57,962 INFO  [Thread-58] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 4 is now TASK_FINISHED\\n2018-11-04 05:05:57,965 INFO  [Thread-59] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - Mesos task 3 is now TASK_FINISHED\\n2018-11-04 05:05:57,995 INFO  [MesosCoarseGrainedSchedulerBackend-mesos-driver] mesos.MesosCoarseGrainedSchedulerBackend (Logging.scala:logInfo(54)) - driver.run() returned with code DRIVER_STOPPED\\n2018-11-04 05:05:57,999 INFO  [dispatcher-event-loop-0] spark.MapOutputTrackerMasterEndpoint (Logging.scala:logInfo(54)) - MapOutputTrackerMasterEndpoint stopped!\\n2018-11-04 05:05:58,003 INFO  [pool-7-thread-1] memory.MemoryStore (Logging.scala:logInfo(54)) - MemoryStore cleared\\n2018-11-04 05:05:58,003 INFO  [pool-7-thread-1] storage.BlockManager (Logging.scala:logInfo(54)) - BlockManager stopped\\n2018-11-04 05:05:58,004 INFO  [pool-7-thread-1] storage.BlockManagerMaster (Logging.scala:logInfo(54)) - BlockManagerMaster stopped\\n2018-11-04 05:05:58,006 INFO  [dispatcher-event-loop-1] scheduler.OutputCommitCoordinator$OutputCommitCoordinatorEndpoint (Logging.scala:logInfo(54)) - OutputCommitCoordinator stopped!\\n2018-11-04 05:05:58,009 INFO  [pool-7-thread-1] spark.SparkContext (Logging.scala:logInfo(54)) - Successfully stopped SparkContext\\n2018-11-04 05:05:58,009 INFO  [pool-7-thread-1] util.ShutdownHookManager (Logging.scala:logInfo(54)) - Shutdown hook called\\n2018-11-04 05:05:58,010 INFO  [pool-7-thread-1] util.ShutdownHookManager (Logging.scala:logInfo(54)) - Deleting directory /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a/pyspark-0a69328c-1da5-4d8b-b627-a57622638e05\\n2018-11-04 05:05:58,010 INFO  [pool-7-thread-1] util.ShutdownHookManager (Logging.scala:logInfo(54)) - Deleting directory /mnt/mesos/sandbox/spark-c7103abd-43df-49eb-8080-34d7a341324a\\n\""
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create mnist data in csv2 format\n",
-    "subprocess.check_output('eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2', shell=True)"
+    "subprocess.check_output('eval spark-submit ${SPARK_OPTS} --verbose tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/tfr --format tfr', shell=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -122,12 +78,13 @@
        "_StoreTrueAction(option_strings=['--tensorboard'], dest='tensorboard', nargs=0, const=True, default=False, type=None, choices=None, help='launch tensorboard process', metavar=None)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# Set the number of executors to the number of available GPU agents\n",
     "num_ps = 0\n",
     "num_executors = 5\n",
     "\n",
@@ -165,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -180,32 +137,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Exception in thread Thread-4:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/opt/conda/lib/python3.6/threading.py\", line 916, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 117, in run\n",
-      "    self.onrecv(msg)\n",
-      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 134, in onrecv\n",
-      "    \"msg\": msg\n",
-      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 214, in sendToFrontEnd\n",
-      "    monitor.send(msg)\n",
-      "  File \"/opt/conda/lib/python3.6/site-packages/sparkmonitor/kernelextension.py\", line 51, in send\n",
-      "    self.comm.send(msg)\n",
-      "AttributeError: 'ScalaMonitor' object has no attribute 'comm'\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make sure you cloned the repo with the adjusted TF 1.11 APIs in mnist_dist/mnist_spark : git clone --single-branch -b leewyang_update_examples https://github.com/yahoo/tensorflowonspark\n",
     "sc = SparkContext(conf=conf).getOrCreate()\n",
@@ -214,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -225,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {
     "scrolled": true
    },
@@ -233,28 +169,6 @@
    "source": [
     "reload(logging)\n",
     "logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.INFO, datefmt='%I:%M:%S')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "b'-rw-r--r--   3 nobody supergroup          0 2018-11-04 05:05 mnist/csv2/train/_SUCCESS\\n-rw-r--r--   3 nobody supergroup    9348476 2018-11-04 05:05 mnist/csv2/train/part-00000\\n-rw-r--r--   3 nobody supergroup   11244092 2018-11-04 05:05 mnist/csv2/train/part-00001\\n-rw-r--r--   3 nobody supergroup   11227072 2018-11-04 05:05 mnist/csv2/train/part-00002\\n-rw-r--r--   3 nobody supergroup   11238388 2018-11-04 05:05 mnist/csv2/train/part-00003\\n-rw-r--r--   3 nobody supergroup   11225055 2018-11-04 05:05 mnist/csv2/train/part-00004\\n-rw-r--r--   3 nobody supergroup   11186122 2018-11-04 05:05 mnist/csv2/train/part-00005\\n-rw-r--r--   3 nobody supergroup   11226573 2018-11-04 05:05 mnist/csv2/train/part-00006\\n-rw-r--r--   3 nobody supergroup   11213312 2018-11-04 05:05 mnist/csv2/train/part-00007\\n-rw-r--r--   3 nobody supergroup   11206429 2018-11-04 05:05 mnist/csv2/train/part-00008\\n-rw-r--r--   3 nobody supergroup   10460475 2018-11-04 05:05 mnist/csv2/train/part-00009\\n'\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Verify training images\n",
-    "# Make sure you unzipped mnist.zip into mnist and ran the mnist_data_setup job via: eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2\n",
-    "train_images_files = \"mnist/csv2/train\"\n",
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls -R {}'.format(train_images_files))))"
    ]
   },
   {
@@ -268,19 +182,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=1, format='csv2', images_labels='mnist/csv2/train', mode='train', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
+      "b'-rw-r--r--   3 nobody supergroup          0 2018-11-05 22:25 mnist/tfr/train/_SUCCESS\\n-rw-r--r--   3 nobody supergroup    4865957 2018-11-05 22:25 mnist/tfr/train/part-r-00000\\n-rw-r--r--   3 nobody supergroup    5853920 2018-11-05 22:25 mnist/tfr/train/part-r-00001\\n-rw-r--r--   3 nobody supergroup    5844694 2018-11-05 22:25 mnist/tfr/train/part-r-00002\\n-rw-r--r--   3 nobody supergroup    5851485 2018-11-05 22:25 mnist/tfr/train/part-r-00003\\n-rw-r--r--   3 nobody supergroup    5844411 2018-11-05 22:25 mnist/tfr/train/part-r-00004\\n-rw-r--r--   3 nobody supergroup    5824177 2018-11-05 22:25 mnist/tfr/train/part-r-00005\\n-rw-r--r--   3 nobody supergroup    5843674 2018-11-05 22:25 mnist/tfr/train/part-r-00006\\n-rw-r--r--   3 nobody supergroup    5835612 2018-11-05 22:25 mnist/tfr/train/part-r-00007\\n-rw-r--r--   3 nobody supergroup    5833012 2018-11-05 22:25 mnist/tfr/train/part-r-00008\\n-rw-r--r--   3 nobody supergroup    5444489 2018-11-05 22:25 mnist/tfr/train/part-r-00009\\n'\n"
      ]
     }
    ],
    "source": [
-    "# Parse arguments for training\n",
-    "args = parser.parse_args(['--mode', 'train', '--epochs', '1',\n",
-    "                          '--batch_size', '100',\n",
-    "                          '--images_labels', train_images_files,\n",
-    "                          '--format', 'csv2',\n",
-    "                          '--steps', '10000',\n",
-    "                          '--model', 'mnist_model'])\n",
-    "print(args)"
+    "# Verify training images\n",
+    "# Make sure you unzipped mnist.zip into mnist and ran the mnist_data_setup job via: eval spark-submit ${SPARK_OPTS} --verbose $(pwd)/tensorflowonspark/examples/mnist/mnist_data_setup.py --output mnist/csv2 --format csv2\n",
+    "train_images_files = \"mnist/tfr/train\"\n",
+    "print(subprocess.check_output(shlex.split('hdfs dfs -ls -R {}'.format(train_images_files))))"
    ]
   },
   {
@@ -291,32 +201,22 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "05:07:01 INFO:Reserving TFSparkNodes \n",
-      "05:07:01 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
-      "05:07:01 INFO:listening for reservations at ('9.0.12.2', 35255)\n",
-      "05:07:01 INFO:Starting TensorFlow on executors\n",
-      "05:07:01 INFO:Waiting for TFSparkNodes to start\n",
-      "05:07:01 INFO:waiting for 5 reservations\n",
-      "05:07:02 INFO:waiting for 5 reservations\n",
-      "05:07:03 INFO:waiting for 5 reservations\n",
-      "05:07:04 INFO:waiting for 5 reservations\n",
-      "05:07:05 INFO:waiting for 1 reservations\n",
-      "05:07:06 INFO:all reservations completed\n",
-      "05:07:06 INFO:All TFSparkNodes started\n",
-      "05:07:06 INFO:{'executor_id': 4, 'host': '10.0.6.118', 'job_name': 'worker', 'task_index': 4, 'port': 43123, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-591qn8pd/listener-z59lcb98', 'authkey': b'\\xe3\\xcb\\xc1-Q\\x80M!\\xa7\\xbe\\xa3C\\x95C\\x0er'}\n",
-      "05:07:06 INFO:{'executor_id': 3, 'host': '10.0.5.40', 'job_name': 'worker', 'task_index': 3, 'port': 32770, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1ncu13a7/listener-ro2yft2p', 'authkey': b'\\x84aI\\xd9\\xf0\\x1aKM\\xaf\\x92?\\x88\\x17\\x1a\\x96/'}\n",
-      "05:07:06 INFO:{'executor_id': 2, 'host': '10.0.5.175', 'job_name': 'worker', 'task_index': 2, 'port': 40772, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-jj2_aw_q/listener-afcmqavz', 'authkey': b\"\\xc7z\\xbd>\\x10\\xd2H\\xb6\\x97:'\\x16\\xb3\\x19\\xe5\\xdf\"}\n",
-      "05:07:06 INFO:{'executor_id': 0, 'host': '10.0.6.30', 'job_name': 'worker', 'task_index': 0, 'port': 44873, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1wrbq0ss/listener-klxyu15s', 'authkey': b'\\x86\\x1e\\xe6&\\xf8/G\\xec\\xbbqf\\x84jOx\\x8f'}\n",
-      "05:07:06 INFO:{'executor_id': 1, 'host': '10.0.5.174', 'job_name': 'worker', 'task_index': 1, 'port': 36186, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-7m9dvgp3/listener-bfj94q8v', 'authkey': b'U\\x1d\\xf8\\xba\\xb7\\xca@#\\x86t\\xd9d\\xe1\\xbcH\\xc8'}\n"
+      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=3, format='tfr', images_labels='mnist/tfr/train', mode='train', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
      ]
     }
    ],
    "source": [
-    "# Start the cluster for training\n",
-    "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, args.num_ps, False, TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)"
+    "# Parse arguments for training\n",
+    "args = parser.parse_args(['--mode', 'train', '--epochs', '3',\n",
+    "                          '--batch_size', '100',\n",
+    "                          '--images_labels', train_images_files,\n",
+    "                          '--format', 'tfr',\n",
+    "                          '--steps', '10000',\n",
+    "                          '--model', 'mnist_model'])\n",
+    "print(args)"
    ]
   },
   {
@@ -330,13 +230,29 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "05:08:41 INFO:Stopping TensorFlow nodes\n",
-      "05:08:41 INFO:Shutting down cluster\n"
+      "10:39:54 INFO:Reserving TFSparkNodes \n",
+      "10:39:54 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
+      "10:39:54 INFO:listening for reservations at ('9.0.7.2', 35579)\n",
+      "10:39:54 INFO:Starting TensorFlow on executors\n",
+      "10:39:55 INFO:Waiting for TFSparkNodes to start\n",
+      "10:39:55 INFO:waiting for 5 reservations\n",
+      "10:39:56 INFO:waiting for 5 reservations\n",
+      "10:39:57 INFO:waiting for 5 reservations\n",
+      "10:39:58 INFO:waiting for 5 reservations\n",
+      "10:39:59 INFO:waiting for 4 reservations\n",
+      "10:40:00 INFO:all reservations completed\n",
+      "10:40:00 INFO:All TFSparkNodes started\n",
+      "10:40:00 INFO:{'executor_id': 2, 'host': '10.0.4.228', 'job_name': 'worker', 'task_index': 2, 'port': 35825, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-c01_wacm/listener-99upz2mo', 'authkey': b'\\xbc\\xce`n\\xdboH\\x91\\xbd/<\\xfa[\\xfb\\x15r'}\n",
+      "10:40:00 INFO:{'executor_id': 4, 'host': '10.0.7.225', 'job_name': 'worker', 'task_index': 4, 'port': 46340, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-afgx4tuj/listener-_al9izeg', 'authkey': b'\\xe7W\\xc8\\xb1\\x82IAP\\x96G\\x9c\\x7fI\\x0b2\\x1c'}\n",
+      "10:40:00 INFO:{'executor_id': 3, 'host': '10.0.4.91', 'job_name': 'worker', 'task_index': 3, 'port': 45528, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-vc5ws3zu/listener-cbt3mo9e', 'authkey': b'uv@$\\xf0\\x94O\\xab\\xb0\\x0c\\x87\\x85K\\xbf\\x90\\x88'}\n",
+      "10:40:00 INFO:{'executor_id': 1, 'host': '10.0.4.116', 'job_name': 'worker', 'task_index': 1, 'port': 39532, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1rwhkoxv/listener-a3_5tb26', 'authkey': b'(tAO\\x19kJ\\x86\\xb6\\x17\\xb1\\x07\\x01\\xfe\\xc4l'}\n",
+      "10:40:00 INFO:{'executor_id': 0, 'host': '10.0.5.225', 'job_name': 'worker', 'task_index': 0, 'port': 39948, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-5rvwiq59/listener-j8dmpe6x', 'authkey': b'\\xfd\\x83\\xe0\\xb7\\xd9\\xceB\\xd0\\xacx\\xd0\\r \\xed\\x840'}\n"
      ]
     }
    ],
    "source": [
-    "cluster.shutdown()"
+    "# Start the cluster for training\n",
+    "cluster = TFCluster.run(sc, mnist_dist.map_fun, args, args.cluster_size, args.num_ps, False, TFCluster.InputMode.TENSORFLOW, driver_ps_nodes=args.driver_ps_nodes)"
    ]
   },
   {
@@ -347,16 +263,16 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "b'Found 10 items\\n-rw-r--r--   3 nobody supergroup        128 2018-11-04 05:07 mnist_model/checkpoint\\n-rw-r--r--   3 nobody supergroup         40 2018-11-04 05:07 mnist_model/events.out.tfevents.1541308031.ip-10-0-6-30.us-west-2.compute.internal\\n-rw-r--r--   3 nobody supergroup     611832 2018-11-04 05:07 mnist_model/graph.pbtxt\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-04 05:07 mnist_model/model.ckpt-0.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-04 05:07 mnist_model/model.ckpt-0.index\\n-rw-r--r--   3 nobody supergroup     178697 2018-11-04 05:07 mnist_model/model.ckpt-0.meta\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-04 05:07 mnist_model/model.ckpt-120.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-04 05:07 mnist_model/model.ckpt-120.index\\n-rw-r--r--   3 nobody supergroup     178697 2018-11-04 05:07 mnist_model/model.ckpt-120.meta\\ndrwxr-xr-x   - nobody supergroup          0 2018-11-04 05:07 mnist_model/train\\n'\n"
+      "10:41:24 INFO:Stopping TensorFlow nodes\n",
+      "10:41:24 INFO:Shutting down cluster\n"
      ]
     }
    ],
    "source": [
-    "# See if mnist_model was successfully created\n",
-    "print(subprocess.check_output(shlex.split('hdfs dfs -ls mnist_model')))"
+    "cluster.shutdown()"
    ]
   },
   {
@@ -370,20 +286,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=1, format='csv2', images_labels='mnist/csv2/train', mode='inference', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
+      "b'Found 10 items\\n-rw-r--r--   3 nobody supergroup        128 2018-11-05 22:40 mnist_model/checkpoint\\n-rw-r--r--   3 nobody supergroup         40 2018-11-05 22:40 mnist_model/events.out.tfevents.1541457603.ip-10-0-5-225.us-west-2.compute.internal\\n-rw-r--r--   3 nobody supergroup     179586 2018-11-05 22:40 mnist_model/graph.pbtxt\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-05 22:40 mnist_model/model.ckpt-0.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-05 22:40 mnist_model/model.ckpt-0.index\\n-rw-r--r--   3 nobody supergroup      66439 2018-11-05 22:40 mnist_model/model.ckpt-0.meta\\n-rw-r--r--   3 nobody supergroup     814168 2018-11-05 22:40 mnist_model/model.ckpt-354.data-00000-of-00001\\n-rw-r--r--   3 nobody supergroup        375 2018-11-05 22:40 mnist_model/model.ckpt-354.index\\n-rw-r--r--   3 nobody supergroup      66439 2018-11-05 22:40 mnist_model/model.ckpt-354.meta\\ndrwxr-xr-x   - nobody supergroup          0 2018-11-05 22:40 mnist_model/train\\n'\n"
      ]
     }
    ],
    "source": [
-    "# Parse arguments for inference\n",
-    "args = parser.parse_args(['--mode', 'inference', '--epochs', '1',\n",
-    "                          '--batch_size', '100',\n",
-    "                          '--images_labels', train_images_files,\n",
-    "                          '--format', 'csv2',\n",
-    "                          '--steps', '10000',\n",
-    "                          '--output', 'predictions',\n",
-    "                          '--model', 'mnist_model'])\n",
-    "print(args)"
+    "# See if mnist_model was successfully created\n",
+    "print(subprocess.check_output(shlex.split('hdfs dfs -ls mnist_model')))"
    ]
   },
   {
@@ -394,23 +303,50 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Namespace(batch_size=100, cluster_size=5, driver_ps_nodes=False, epochs=3, format='tfr', images_labels='mnist/tfr/train', mode='inference', model='mnist_model', num_ps=0, output='predictions', rdma=False, readers=10, shuffle_size=1000, steps=10000, tensorboard=False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parse arguments for inference\n",
+    "args = parser.parse_args(['--mode', 'inference', '--epochs', '3',\n",
+    "                          '--batch_size', '100',\n",
+    "                          '--images_labels', train_images_files,\n",
+    "                          '--format', 'tfr',\n",
+    "                          '--steps', '10000',\n",
+    "                          '--output', 'predictions',\n",
+    "                          '--model', 'mnist_model'])\n",
+    "print(args)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "05:08:59 INFO:Reserving TFSparkNodes \n",
-      "05:08:59 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
-      "05:08:59 INFO:listening for reservations at ('9.0.12.2', 39571)\n",
-      "05:08:59 INFO:Starting TensorFlow on executors\n",
-      "05:08:59 INFO:Waiting for TFSparkNodes to start\n",
-      "05:08:59 INFO:waiting for 5 reservations\n",
-      "05:09:00 INFO:waiting for 5 reservations\n",
-      "05:09:01 INFO:all reservations completed\n",
-      "05:09:01 INFO:All TFSparkNodes started\n",
-      "05:09:01 INFO:{'executor_id': 0, 'host': '10.0.5.174', 'job_name': 'worker', 'task_index': 0, 'port': 41609, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-4bqua8ry/listener-91eahqme', 'authkey': b'\\xb5g\\xef+\\x9e_E\\xf4\\x9ap\\xc9M\\xc5\\x02\\xe8\\xc3'}\n",
-      "05:09:01 INFO:{'executor_id': 3, 'host': '10.0.6.118', 'job_name': 'worker', 'task_index': 3, 'port': 35141, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-77vqqli_/listener-p771rtqc', 'authkey': b'\\xd8=\\xf4G\\x92\\xfdD\\xf3\\x99\\x17\\xc1\\xe1Y \\xba\\x1c'}\n",
-      "05:09:01 INFO:{'executor_id': 1, 'host': '10.0.5.175', 'job_name': 'worker', 'task_index': 1, 'port': 44574, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-kqr9hebd/listener-qdjrch5x', 'authkey': b'\\x82\\xf0\\x1b\\xb7o\\x0cE\\xbb\\x8cK\\x06\\xae\\xca6\\x19\\x94'}\n",
-      "05:09:01 INFO:{'executor_id': 2, 'host': '10.0.6.30', 'job_name': 'worker', 'task_index': 2, 'port': 46388, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-jr7vqwwm/listener-glpojvcl', 'authkey': b'\\xb3k\\xb7+J\\x95D*\\xa8;\\x7ff\\x1dR\\xb6\\x13'}\n",
-      "05:09:01 INFO:{'executor_id': 4, 'host': '10.0.5.40', 'job_name': 'worker', 'task_index': 4, 'port': 46572, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1lxyryy5/listener-_3zvctj1', 'authkey': b'\\x1e\\xf4C\\x04\\x82\\x82N\\xf6\\xb8B[\\xe7\\xcb\\x0c\\x1bT'}\n"
+      "10:41:48 INFO:Reserving TFSparkNodes \n",
+      "10:41:48 INFO:cluster_template: {'ps': range(0, 0), 'worker': range(0, 5)}\n",
+      "10:41:48 INFO:listening for reservations at ('9.0.7.2', 35357)\n",
+      "10:41:48 INFO:Starting TensorFlow on executors\n",
+      "10:41:48 INFO:Waiting for TFSparkNodes to start\n",
+      "10:41:48 INFO:waiting for 5 reservations\n",
+      "10:41:49 INFO:waiting for 5 reservations\n",
+      "10:41:50 INFO:all reservations completed\n",
+      "10:41:50 INFO:All TFSparkNodes started\n",
+      "10:41:50 INFO:{'executor_id': 0, 'host': '10.0.4.228', 'job_name': 'worker', 'task_index': 0, 'port': 40124, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-0gzba7qn/listener-52gcid_c', 'authkey': b'-Tic\\xeb\\xefH\\xa2\\x97\\x9c\\x1bTs\\xbd5\\xe8'}\n",
+      "10:41:50 INFO:{'executor_id': 4, 'host': '10.0.7.225', 'job_name': 'worker', 'task_index': 4, 'port': 39938, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-_45qn21g/listener-soc8dl60', 'authkey': b'\\x08\\xe2)\\xc6\\x13:Gp\\x9b1\\xd2\\x8c|\\x17\\xf1m'}\n",
+      "10:41:50 INFO:{'executor_id': 2, 'host': '10.0.4.116', 'job_name': 'worker', 'task_index': 2, 'port': 38315, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-w599fmp7/listener-ng1nrq8q', 'authkey': b'+j\\xc0D\\xa3\\x94D\\x19\\x88\\xe7wZ\\xb6\\xfdJ:'}\n",
+      "10:41:50 INFO:{'executor_id': 1, 'host': '10.0.4.91', 'job_name': 'worker', 'task_index': 1, 'port': 37554, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-rz35vv19/listener-7ogl_txj', 'authkey': b's\\x8a\\xe4\\r\\xad\\x07Eo\\xa1{\\xe3\\xcfl\\xfaId'}\n",
+      "10:41:50 INFO:{'executor_id': 3, 'host': '10.0.5.225', 'job_name': 'worker', 'task_index': 3, 'port': 38123, 'tb_pid': 0, 'tb_port': 0, 'addr': '/tmp/pymp-1ox2i9k7/listener-3lmqwmv0', 'authkey': b'N\\x91*\\t\\x02\\xf6E\\\\\\xb8\\x07\\x9b\\xae\\xfaH.\\xeb'}\n"
      ]
     }
    ],
@@ -421,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "scrolled": true
    },
@@ -432,29 +368,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['0 0', '6 6', '4 4', '4 4', '4 4', '9 9', '2 2', '3 3', '8 8', '8 8']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "predictions.take(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "10:44:04 INFO:Stopping TensorFlow nodes\n",
+      "10:44:04 INFO:Shutting down cluster\n"
+     ]
+    }
+   ],
    "source": [
     "cluster.shutdown()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "scrolled": true
    },
@@ -481,6 +437,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": false,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": false,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/notebooks/TFoS.ipynb
+++ b/notebooks/TFoS.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },


### PR DESCRIPTION
Background:
https://github.com/yahoo/TensorFlowOnSpark/pull/361 fixes broken examples, in particular `mnist_dist.py` and `mnist_spark.py` by introducing TF 1.11 dataset api and minor bug fixes. We were using an older version in our `notebooks/TFoS.ipynb` examples which broke the example.

Accordingly, I updated our TFoS example.

Updated TFoS.ipynb for TF 1.11:

* Updated to TF 1.11 Dataset API example https://github.com/yahoo/TensorFlowOnSpark/tree/master/examples/mnist/tf#using-dataset
* Added more cells for data-setup jobs and pre-req within notebook for better user experience

Also:

* Cleaner Notebook tested in Classic Notebook View
* Default to more valid GPU example (Distributed TF without GPUs makes very little sense)

Testing:
Feel free to test it with the most current latest image by simply cloning this branch into your workspace: `git clone --single-branch -b fabianbaier-tfos-patch-dataset https://github.com/dcos-labs/dcos-jupyterlab-service`
