### PR TITLE
Bump Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Major Features and Improvements
 
+* Based on Debian [9.6](https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian96---linux-amd64)
+
 ### Package Additions
 
 * boost
@@ -37,14 +39,15 @@
 ### Package Bumps
 
 * dask 1.0.0
-* distributed 1.25.0
+* distributed 1.25.1
 * hadoop 2.9.2
+* horovod 0.15.2
 * jupyterlab 0.35.4
-* mlflow 0.8.0
+* mlflow 0.8.1
 * pyarrow 0.11.0
 * r-base 3.5.1
-* ray[rllib] 0.6.0
-* setuptools 40.4.3
+* ray[debug,rllib] 0.6.1
+* setuptools 40.6.3
 * tensorflow 1.11.0
 * tensorflowonspark 1.4.1
 * toree 0.3.0-incubating

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# debian:9.5 - linux; amd64
-# https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian95---linux-amd64
-FROM debian@sha256:00c5748eb465a0139063c544de181177da504dfa4e545ac3c0ecd13b7363e70f
+# debian:9.6 - linux; amd64
+# https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian96---linux-amd64
+FROM debian@sha256:38236c068c393272ad02db100e09cac36a5465149e2924a035ee60d6c60c38fe
 
 ARG BUILD_DATE
 ARG CODENAME="stretch"

--- a/Dockerfile-data-toolkit
+++ b/Dockerfile-data-toolkit
@@ -1,6 +1,6 @@
-# debian:9.5 - linux; amd64
-# https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian95---linux-amd64
-FROM debian@sha256:00c5748eb465a0139063c544de181177da504dfa4e545ac3c0ecd13b7363e70f
+# debian:9.6 - linux; amd64
+# https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian96---linux-amd64
+FROM debian@sha256:38236c068c393272ad02db100e09cac36a5465149e2924a035ee60d6c60c38fe
 
 ARG BUILD_DATE
 ARG CODENAME="stretch"

--- a/data-toolkit-root-conda-base-env.yml
+++ b/data-toolkit-root-conda-base-env.yml
@@ -18,6 +18,7 @@ dependencies:
 - cmake
 - colour
 - conda-pack
+- curl=7.62.*
 - cython
 - dask=1.0.*
 - dask-ml
@@ -43,6 +44,7 @@ dependencies:
 - invoke
 - itsdangerous
 - keras
+- libcurl=7.62.*
 - libhdfs3
 - lxml
 - lz4
@@ -62,6 +64,7 @@ dependencies:
 - pillow
 - plotly
 - pluggy
+- protobuf=3.6.*
 - psutil
 - py
 - pyarrow=0.11.*
@@ -94,6 +97,7 @@ dependencies:
 - sdl2
 - selenium
 - setproctitle
+- setuptools=40.6.*
 - simplejson
 - smmap2
 - sqlalchemy
@@ -113,13 +117,12 @@ dependencies:
   - horovod
   - mlflow==0.8.*
   - opencv-python
-  - protobuf==3.6.*
   - psycopg2-binary
   - pyglet
   - PyOpenGL
-  - ray[rllib]==0.6.*
+  - ray[debug,rllib]==0.6.*
   - redis
-  - setuptools==40.4.*
+  - s3cmd
   - tensorflow==1.11.*
   - tensorflow-hub
   - tensorflowonspark==1.4.*

--- a/jupyter-root-conda-base-env.yml
+++ b/jupyter-root-conda-base-env.yml
@@ -20,6 +20,7 @@ dependencies:
 - cmake
 - colour
 - conda-pack
+- curl=7.62.*
 - cython
 - dask=1.0.*
 - dask-ml
@@ -53,6 +54,7 @@ dependencies:
 - jupyter_enterprise_gateway
 - jupyter_kernel_gateway
 - keras
+- libcurl=7.62.*
 - libhdfs3
 - lxml
 - lz4
@@ -77,6 +79,7 @@ dependencies:
 - pillow
 - plotly
 - pluggy
+- protobuf=3.6.*
 - psutil
 - py
 - pyarrow=0.11.*
@@ -111,6 +114,7 @@ dependencies:
 - sdl2
 - selenium
 - setproctitle
+- setuptools=40.6.*
 - simplejson
 - smmap2
 - sqlalchemy
@@ -132,6 +136,7 @@ dependencies:
   - https://dist.apache.org/repos/dist/release/incubator/toree/0.3.0-incubating/toree-pip/toree-0.3.0.tar.gz
   - https://github.com/quantopian/pgcontents/archive/master.tar.gz
   - https://github.com/vishnu2kmohan/jupyter-spark-history-dcos/archive/0.1.0.zip
+  - ipykernel==5.1.*
   - jupyterlab-git
   - jupyterlab_github
   - jupyterlab_iframe
@@ -142,16 +147,14 @@ dependencies:
   - pixiedust
   - pixiedust_node
   - pixiegateway
-  - protobuf==3.6.*
   - psycopg2-binary
   - pyglet
   - PyOpenGL
-  - ray[rllib]==0.6.*
+  - ray[debug,rllib]==0.6.*
   - redis
   - rise
   - s3cmd
   - s3contents
-  - setuptools==40.4.*
   - sparkmonitor
   - tensorflow==1.11.*
   - tensorflow-hub


### PR DESCRIPTION
* Bump to Debian 9.6 to get ahead of any (known) CVEs
* Need to pin `cURL` to 7.62.x because 7.63.x is borked (libraries are not linked properly)
* Move a couple of libraries (`setuptools` and `protobuf`) to conda-forge packages
* Pin `ipykernel` to 5.1.x because it was getting downgraded to 4.x in the `pip` install phase

These changes were used to generate the following Docker Images:
* mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4
* mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4-gpu
* mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0
* mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0-gpu

Tested with `TFoS.ipynb`