### PR TITLE
Fix resource.assets.container.docker.jupyter-docker-gpu

### DIFF
--- a/universe/resource.json
+++ b/universe/resource.json
@@ -11,7 +11,7 @@
     "container": {
       "docker": {
         "jupyter-docker": "mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4",
-        "jupyter-docker-gpu": "mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4",
+        "jupyter-docker-gpu": "mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4-gpu",
         "worker-docker": "mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0",
         "worker-docker-gpu": "mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0-gpu"
       }


### PR DESCRIPTION
Needs to point to `mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4-gpu`